### PR TITLE
Story 1.9 – User Logout

### DIFF
--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -439,6 +439,56 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /auth/logout:
+    post:
+      summary: Log out user
+      description: |
+        Securely logs out the user by invalidating their refresh token and clearing the refresh token cookie.
+        
+        **Security Features:**
+        - Invalidates the refresh token server-side by incrementing the token version
+        - Clears the refresh token cookie from the browser
+        - All existing access tokens become invalid immediately
+        - Idempotent: safe to call multiple times
+        
+        **Token Invalidation:**
+        - Uses token versioning to immediately invalidate all existing tokens
+        - No database lookups required on subsequent requests
+        - Scales efficiently with high traffic
+      responses:
+        "200":
+          description: Logout successful.
+          headers:
+            Set-Cookie:
+              description: Clears the refresh token cookie
+              schema:
+                type: string
+                example: refreshToken=; HttpOnly; Secure; SameSite=Lax; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [success]
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+              examples:
+                success:
+                  value:
+                    success: true
+        "401":
+          description: No valid session or refresh token.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorSimple"
+              examples:
+                not_authenticated:
+                  value: { code: NOT_AUTHENTICATED }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
 components:
   responses:
     InternalError:

--- a/backend/tests/auth.logout.test.ts
+++ b/backend/tests/auth.logout.test.ts
@@ -1,0 +1,192 @@
+import request from 'supertest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { makeLoginSupabaseMock, mockMaybeSingle } from './utils/loginSupabaseMock';
+
+const mockJwtVerify = vi.fn();
+vi.mock('jsonwebtoken', () => ({
+  default: {
+    verify: mockJwtVerify,
+  },
+  verify: mockJwtVerify,
+}));
+
+const mockGenerateAccessToken = vi.fn();
+const mockGenerateRefreshToken = vi.fn();
+const mockInvalidateRefreshToken = vi.fn();
+const mockVerifyTokenVersion = vi.fn();
+
+vi.doMock('../src/utils/tokens', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../src/utils/tokens')>();
+  return {
+    ...original,
+    generateAccessToken: mockGenerateAccessToken,
+    generateRefreshToken: mockGenerateRefreshToken,
+    invalidateRefreshToken: mockInvalidateRefreshToken,
+    verifyTokenVersion: mockVerifyTokenVersion,
+  };
+});
+
+let app: ReturnType<Awaited<typeof import('../src/app')>['createApp']>;
+
+async function buildApp() {
+  const mod = await import('../src/app');
+  return mod.createApp();
+}
+
+beforeEach(async () => {
+  vi.resetAllMocks();
+  await vi.resetModules();
+  vi.doMock('../src/lib/supabase', () => ({
+    supabase: makeLoginSupabaseMock(),
+  }));
+  app = await buildApp();
+});
+
+describe('POST /auth/logout', () => {
+  const testUser = {
+    id: 'test-user-id',
+    signup_email: 'test@example.com',
+    full_name: 'Test User',
+    zid: 'z1234567',
+    level: 'undergrad' as const,
+    year_intake: 2023,
+    is_indonesian: true,
+    program: 'Computer Science',
+    major: 'Software Engineering',
+    password_hash: 'hashed-password',
+    status: 'ACTIVE' as const,
+    token_version: 1,
+  };
+
+  it('should successfully logout with valid refresh token', async () => {
+    // Mock JWT verification
+    mockJwtVerify.mockReturnValue({
+      sub: testUser.id,
+      tokenVersion: 1,
+    });
+
+    // Mock token version verification
+    mockVerifyTokenVersion.mockResolvedValue(true);
+
+    const response = await request(app)
+      .post('/api/auth/logout')
+      .set('Cookie', 'refreshToken=valid-token')
+      .expect(200);
+
+    expect(response.body).toEqual({ success: true });
+    expect(mockInvalidateRefreshToken).toHaveBeenCalledWith(testUser.id);
+  });
+
+  it('should clear refresh token cookie on successful logout', async () => {
+    // Mock JWT verification
+    mockJwtVerify.mockReturnValue({
+      sub: testUser.id,
+      tokenVersion: 1,
+    });
+
+    // Mock token version verification
+    mockVerifyTokenVersion.mockResolvedValue(true);
+
+    const response = await request(app)
+      .post('/api/auth/logout')
+      .set('Cookie', 'refreshToken=valid-token')
+      .expect(200);
+
+    // Check that Set-Cookie header clears the cookie
+    const setCookieHeader = response.headers['set-cookie'];
+    expect(setCookieHeader).toBeDefined();
+    
+    const refreshTokenCookie = setCookieHeader.find((cookie: string) => 
+      cookie.startsWith('refreshToken=')
+    );
+    expect(refreshTokenCookie).toContain('Expires=Thu, 01 Jan 1970 00:00:00 GMT');
+    expect(refreshTokenCookie).toContain('HttpOnly');
+    expect(refreshTokenCookie).toContain('Secure');
+    expect(refreshTokenCookie).toContain('SameSite=Lax');
+  });
+
+  it('should return 401 when no refresh token cookie is provided', async () => {
+    const response = await request(app)
+      .post('/api/auth/logout')
+      .expect(401);
+
+    expect(response.body).toEqual({ code: 'NOT_AUTHENTICATED' });
+  });
+
+  it('should return 401 when refresh token is invalid', async () => {
+    // Mock JWT verification to throw error
+    mockJwtVerify.mockImplementation(() => {
+      throw new Error('Invalid token');
+    });
+
+    const response = await request(app)
+      .post('/api/auth/logout')
+      .set('Cookie', 'refreshToken=invalid-token')
+      .expect(401);
+
+    expect(response.body).toEqual({ code: 'NOT_AUTHENTICATED' });
+  });
+
+  it('should return 401 when refresh token is malformed', async () => {
+    // Mock JWT verification to throw error
+    mockJwtVerify.mockImplementation(() => {
+      throw new Error('Invalid token');
+    });
+
+    const response = await request(app)
+      .post('/api/auth/logout')
+      .set('Cookie', 'refreshToken=malformed.jwt.token')
+      .expect(401);
+
+    expect(response.body).toEqual({ code: 'NOT_AUTHENTICATED' });
+  });
+
+  it('should be idempotent - multiple logout calls should return 200', async () => {
+    // Mock JWT verification
+    mockJwtVerify.mockReturnValue({
+      sub: testUser.id,
+      tokenVersion: 1,
+    });
+
+    // First call - token is valid
+    mockVerifyTokenVersion.mockResolvedValueOnce(true);
+    
+    const response1 = await request(app)
+      .post('/api/auth/logout')
+      .set('Cookie', 'refreshToken=valid-token')
+      .expect(200);
+
+    expect(response1.body).toEqual({ success: true });
+
+    // Second call - token is already invalidated (idempotent)
+    mockVerifyTokenVersion.mockResolvedValueOnce(false);
+    
+    const response2 = await request(app)
+      .post('/api/auth/logout')
+      .set('Cookie', 'refreshToken=valid-token')
+      .expect(200);
+
+    expect(response2.body).toEqual({ success: true });
+  });
+
+  it('should handle database errors gracefully', async () => {
+    // Mock JWT verification
+    mockJwtVerify.mockReturnValue({
+      sub: testUser.id,
+      tokenVersion: 1,
+    });
+
+    // Mock token version verification
+    mockVerifyTokenVersion.mockResolvedValue(true);
+    
+    // Mock database error
+    mockInvalidateRefreshToken.mockRejectedValue(new Error('Database error'));
+
+    const response = await request(app)
+      .post('/api/auth/logout')
+      .set('Cookie', 'refreshToken=valid-token')
+      .expect(500);
+
+    expect(response.body).toEqual({ code: 'INTERNAL' });
+  });
+});

--- a/backend/tests/auth.refresh.test.ts
+++ b/backend/tests/auth.refresh.test.ts
@@ -18,14 +18,18 @@ describe('POST /api/auth/refresh', () => {
     vi.doMock('jsonwebtoken', () => ({
       verify: (token: string, secret: string) => {
         if (!token || token === 'bad') throw new Error('invalid');
-        return { sub: 'user-123' };
+        return { sub: 'user-123', tokenVersion: 1 };
       },
       sign: vi.fn(),
     }));
-    // Mock tokens to produce deterministic access token
+    // Mock tokens to produce deterministic access token and verify token version
     vi.doMock('../src/utils/tokens', async (importOriginal) => {
       const original = await importOriginal<typeof import('../src/utils/tokens')>();
-      return { ...original, generateAccessToken: () => 'new_access_token' };
+      return { 
+        ...original, 
+        generateAccessToken: () => 'new_access_token',
+        verifyTokenVersion: () => true // Mock token version verification to always return true
+      };
     });
     app = await buildApp();
   });

--- a/supabase/migrations/202509010005_add_token_version.sql
+++ b/supabase/migrations/202509010005_add_token_version.sql
@@ -1,0 +1,18 @@
+-- Add token_version column to user_signups table for token invalidation
+ALTER TABLE user_signups 
+ADD COLUMN IF NOT EXISTS token_version INTEGER NOT NULL DEFAULT 1;
+
+-- Create index for efficient token version lookups
+CREATE INDEX IF NOT EXISTS idx_user_signups_token_version ON user_signups (token_version);
+
+-- Create RPC function to increment token version
+CREATE OR REPLACE FUNCTION increment_token_version(user_id UUID)
+RETURNS VOID AS $$
+BEGIN
+  UPDATE user_signups 
+  SET 
+    token_version = token_version + 1,
+    updated_at = NOW()
+  WHERE id = user_id;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
- Add POST /auth/logout route
- Invalidate refresh tokens via token versioning
- Clear HttpOnly, Secure refresh token cookie
- Update auth refresh flow to verify token version
- Add token_version column and RPC in database
- Add tests for logout endpoint and refresh token validation
- Update OpenAPI spec

<img width="1701" height="652" alt="Screenshot from 2025-09-06 00-54-42" src="https://github.com/user-attachments/assets/22368e63-3af3-40c2-93f8-e2daaa66ad75" />
