### PR TITLE
Story 2.20 – List My Skills

### DIFF
--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -10,6 +10,9 @@ servers:
   - url: http://localhost:5000/api
     description: Local dev
 
+security:
+  - bearerAuth: []
+
 paths:
   /auth/register:
     post:
@@ -550,6 +553,12 @@ paths:
                     code: NOT_AUTHENTICATED
 
 components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      
   responses:
     InternalError:
       description: Internal error

--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -510,6 +510,45 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /profile/skills:
+    get:
+      summary: List all skills for the authenticated user
+      description: |
+        Returns all skills linked to the authenticated user's profile via `profile_skills`.
+        Names are deduped and sorted alphabetically.
+        
+        **Auth:** Bearer token required.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: List of skills for the user (may be empty)
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Skill"
+              examples:
+                some_skills:
+                  value:
+                    - id: 12
+                      name: Python
+                    - id: 34
+                      name: SQL
+                no_skills:
+                  value: []
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorSimple"
+              examples:
+                not_authenticated:
+                  value:
+                    code: NOT_AUTHENTICATED
+
 components:
   responses:
     InternalError:
@@ -711,3 +750,14 @@ components:
         resumeToken:
           description: The new resume token bound to the new email
           example: "res_def456..."
+
+    Skill:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+        name:
+          type: string

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -8,10 +8,11 @@ import swaggerUi from 'swagger-ui-express';
 import cookieParser from 'cookie-parser';
 
 import authRoutes from './routes/auth.routes';
+import profileRoutes from './routes/profile.routes';
 
 export const createApp = () => {
-  const app = express();
   
+  const app = express();
   // Configure CORS to allow frontend origin with credentials
   app.use(cors({
     origin: ['http://localhost:3000', 'http://127.0.0.1:3000'],
@@ -43,6 +44,7 @@ export const createApp = () => {
   // -----------------------------------------
 
   app.use('/api', authRoutes);
+  app.use('/api', profileRoutes);
 
   return app;
 };

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -45,6 +45,7 @@ import {
   updateEmailChangeAttempts,
   resendEmailChangeOtp,
 } from "../services/email.service";
+import { getProfileSkills } from "../services/skills.service";
 
 const router = Router();
 
@@ -929,5 +930,27 @@ router.delete("/user/email/cancel-change", async (req, res) => {
     return res.status(500).json({ code: "INTERNAL" });
   }
 }); 
+
+router.get("/profile/skills", async (req, res) => {
+  const accessToken = req.headers.authorization?.split(" ")[1];
+  if (!accessToken) {
+    return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+  }
+  let userId: string;
+  try {
+    const decoded = jwt.verify(accessToken, process.env.JWT_SECRET!) as any;
+    userId = decoded.sub;
+    if (!userId) throw new Error("No userId in token");
+  } catch {
+    return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+  }
+  try {
+    const skills = await getProfileSkills(userId);
+    return res.status(200).json(skills);
+  } catch (err) {
+    console.error("getProfileSkills.error", err);
+    return res.status(500).json({ code: "INTERNAL" });
+  }
+});
 
 export default router;

--- a/backend/src/routes/auth.routes.ts
+++ b/backend/src/routes/auth.routes.ts
@@ -948,26 +948,4 @@ router.delete("/user/email/cancel-change", async (req, res) => {
   }
 }); 
 
-router.get("/profile/skills", async (req, res) => {
-  const accessToken = req.headers.authorization?.split(" ")[1];
-  if (!accessToken) {
-    return res.status(401).json({ code: "NOT_AUTHENTICATED" });
-  }
-  let userId: string;
-  try {
-    const decoded = jwt.verify(accessToken, process.env.JWT_SECRET!) as any;
-    userId = decoded.sub;
-    if (!userId) throw new Error("No userId in token");
-  } catch {
-    return res.status(401).json({ code: "NOT_AUTHENTICATED" });
-  }
-  try {
-    const skills = await getProfileSkills(userId);
-    return res.status(200).json(skills);
-  } catch (err) {
-    console.error("getProfileSkills.error", err);
-    return res.status(500).json({ code: "INTERNAL" });
-  }
-});
-
 export default router;

--- a/backend/src/routes/profile.routes.ts
+++ b/backend/src/routes/profile.routes.ts
@@ -1,0 +1,29 @@
+import { Router } from "express";
+import jwt from "jsonwebtoken";
+import { getProfileSkills } from "../services/skills.service";
+
+const router = Router();
+
+router.get("/profile/skills", async (req, res) => {
+  const accessToken = req.headers.authorization?.split(" ")[1];
+  if (!accessToken) {
+    return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+  }
+  let userId: string;
+  try {
+    const decoded = jwt.verify(accessToken, process.env.JWT_SECRET!) as any;
+    userId = decoded.sub;
+    if (!userId) throw new Error("No userId in token");
+  } catch {
+    return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+  }
+  try {
+    const skills = await getProfileSkills(userId);
+    return res.status(200).json(skills);
+  } catch (err) {
+    console.error("getProfileSkills.error", err);
+    return res.status(500).json({ code: "INTERNAL" });
+  }
+});
+
+export default router;

--- a/backend/src/services/skills.service.ts
+++ b/backend/src/services/skills.service.ts
@@ -1,0 +1,23 @@
+import { supabase } from "../lib/supabase";
+
+/**
+ * Fetch all skills for a given profile (user) ID, sorted alphabetically by name.
+ * @param profileId The UUID of the profile/user
+ * @returns Array of skills: [{ id, name }]
+ */
+export async function getProfileSkills(profileId: string): Promise<Array<{ id: number; name: string }>> {
+	const { data, error } = await supabase
+		.from("profile_skills")
+		.select("skill_id, skills(id, name)")
+		.eq("profile_id", profileId);
+	if (error) throw error;
+    
+	const skills = (data || [])
+		.map((row: any) => row.skills)
+		.filter((s: any): s is { id: number; name: string } => !!s)
+		.reduce((acc: Record<number, { id: number; name: string }>, skill) => {
+			acc[skill.id] = skill;
+			return acc;
+		}, {});
+	return Object.values(skills).sort((a, b) => a.name.localeCompare(b.name));
+}

--- a/backend/tests/auth.profile-skills.test.ts
+++ b/backend/tests/auth.profile-skills.test.ts
@@ -1,0 +1,106 @@
+import request from 'supertest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let app: ReturnType<Awaited<typeof import('../src/app')>['createApp']>;
+const TEST_USER_ID = 'user-123';
+const NO_SKILLS_USER_ID = 'user-456';
+
+async function buildApp() {
+  const mod = await import('../src/app');
+  return mod.createApp();
+}
+
+beforeEach(async () => {
+  await vi.resetModules();
+
+  // Always mock JWT to return TEST_USER_ID by default
+  vi.doMock('jsonwebtoken', () => ({
+    verify: () => ({ sub: TEST_USER_ID }),
+  }));
+
+  // Mock Supabase for skills
+  vi.doMock('../src/lib/supabase', () => ({
+    supabase: {
+      from: (table: string) => {
+        if (table === 'profile_skills') {
+          return {
+            select: (_: string) => ({
+              eq: (_col: string, val: string) => ({
+                data: val === TEST_USER_ID
+                  ? [
+                      { skills: { id: 1, name: 'Python' } },
+                      { skills: { id: 2, name: 'SQL' } },
+                    ]
+                  : [],
+                error: null,
+              }),
+            }),
+          };
+        }
+        return { select: () => ({ eq: () => ({ data: [], error: null }) }) };
+      },
+    },
+  }));
+
+  // Mock tokens
+  vi.doMock('../src/utils/tokens', () => ({
+    generateAccessToken: (userId: string) => `token-for-${userId}`,
+  }));
+
+  app = await buildApp();
+});
+
+describe('GET /profile/skills', () => {
+  it('should return 401 if no token is provided', async () => {
+    const res = await request(app).get('/api/profile/skills');
+    expect(res.status).toBe(401);
+    expect(res.body.code).toBe('NOT_AUTHENTICATED');
+  });
+
+  it('should return 200 and an array of skills for an authenticated user', async () => {
+    const res = await request(app)
+      .get('/api/profile/skills')
+      .set('Authorization', `Bearer token-for-${TEST_USER_ID}`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body).toEqual([
+      { id: 1, name: 'Python' },
+      { id: 2, name: 'SQL' },
+    ]);
+  });
+
+  it('should return 200 and an empty array if the user has no skills', async () => {
+    await vi.resetModules();
+    vi.doMock('jsonwebtoken', () => ({
+      verify: () => ({ sub: NO_SKILLS_USER_ID }),
+    }));
+    vi.doMock('../src/lib/supabase', () => ({
+      supabase: {
+        from: (table: string) => {
+          if (table === 'profile_skills') {
+            return {
+              select: (_: string) => ({
+                eq: (_col: string, val: string) => ({
+                  data: [],
+                  error: null,
+                }),
+              }),
+            };
+          }
+          return { select: () => ({ eq: () => ({ data: [], error: null }) }) };
+        },
+      },
+    }));
+    vi.doMock('../src/utils/tokens', () => ({
+      generateAccessToken: (userId: string) => `token-for-${userId}`,
+    }));
+    const mod = await import('../src/app');
+    const appNoSkills = mod.createApp();
+    const res = await request(appNoSkills)
+      .get('/api/profile/skills')
+      .set('Authorization', `Bearer token-for-${NO_SKILLS_USER_ID}`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBe(0);
+  });
+});

--- a/backend/tests/auth.profile-skills.test.ts
+++ b/backend/tests/auth.profile-skills.test.ts
@@ -1,149 +1,128 @@
 import request from 'supertest';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { type Scenario, makeSupabaseMock } from './utils/supabaseMock';
 
 let app: ReturnType<Awaited<typeof import('../src/app')>['createApp']>;
-const TEST_USER_ID = 'user-123';
-const NO_SKILLS_USER_ID = 'user-456';
+let scenario: Scenario;
+
+const mockJwtVerify = vi.fn();
+vi.mock('jsonwebtoken', () => ({
+	default: { verify: mockJwtVerify },
+	verify: mockJwtVerify,
+}));
 
 async function buildApp() {
-  const mod = await import('../src/app');
-  return mod.createApp();
+	const mod = await import('../src/app');
+	return mod.createApp();
 }
 
 beforeEach(async () => {
-  await vi.resetModules();
-
-  // Always mock JWT to return TEST_USER_ID by default
-  vi.doMock('jsonwebtoken', () => ({
-    verify: () => ({ sub: TEST_USER_ID }),
-  }));
-
-  // Mock Supabase for skills
-  vi.doMock('../src/lib/supabase', () => ({
-    supabase: {
-      from: (table: string) => {
-        if (table === 'profile_skills') {
-          return {
-            select: (_: string) => ({
-              eq: (_col: string, val: string) => ({
-                data: val === TEST_USER_ID
-                  ? [
-                      { skills: { id: 1, name: 'Python' } },
-                      { skills: { id: 2, name: 'SQL' } },
-                    ]
-                  : [],
-                error: null,
-              }),
-            }),
-          };
-        }
-        return { select: () => ({ eq: () => ({ data: [], error: null }) }) };
-      },
-    },
-  }));
-
-  // Mock tokens
-  vi.doMock('../src/utils/tokens', () => ({
-    generateAccessToken: (userId: string) => `token-for-${userId}`,
-  }));
-
-  app = await buildApp();
+	await vi.resetModules();
+	scenario = {
+		adminUserByEmail: null,
+		adminListUsers: [],
+		activeProfileByEmail: null,
+		activeProfileByZid: null,
+		pendingByEmail: null,
+		pendingByZid: null,
+		expiredByZid: null,
+		expiredByEmail: null,
+		createdSignupId: 'signup-created-1',
+		revivedSignupId: 'signup-revived-1',
+	};
+	// Custom supabase mock for profile_skills
+	vi.doMock('../src/lib/supabase', () => ({
+		supabase: {
+			from: (table: string) => {
+				if (table === 'profile_skills') {
+					return {
+						select: () => ({
+							eq: (_col: string, _val: any) => ({
+								data: [
+									{ skills: { id: 1, name: 'React' } },
+									{ skills: { id: 2, name: 'Node.js' } },
+									{ skills: { id: 3, name: 'TypeScript' } },
+								],
+								error: null,
+							}),
+						}),
+					};
+				}
+				// fallback to default mock
+				return makeSupabaseMock(scenario).from(table);
+			},
+		},
+	}));
+	app = await buildApp();
 });
 
-describe('GET /profile/skills', () => {
-  it('should return 401 if no token is provided', async () => {
-    const res = await request(app).get('/api/profile/skills');
-    expect(res.status).toBe(401);
-    expect(res.body.code).toBe('NOT_AUTHENTICATED');
-  });
+const route = '/api/profile/skills';
 
-  it('should return 200 and an array of skills for an authenticated user', async () => {
-    const res = await request(app)
-      .get('/api/profile/skills')
-      .set('Authorization', `Bearer token-for-${TEST_USER_ID}`);
-    expect(res.status).toBe(200);
-    expect(Array.isArray(res.body)).toBe(true);
-    expect(res.body).toEqual([
-      { id: 1, name: 'Python' },
-      { id: 2, name: 'SQL' },
-    ]);
-  });
+describe('GET /api/profile/skills', () => {
+	it('401: returns NOT_AUTHENTICATED if no Authorization header', async () => {
+		const res = await request(app).get(route);
+		expect(res.status).toBe(401);
+		expect(res.body).toEqual({ code: 'NOT_AUTHENTICATED' });
+	});
 
-  it('should return 200 and an empty array if the user has no skills', async () => {
-    await vi.resetModules();
-    vi.doMock('jsonwebtoken', () => ({
-      verify: () => ({ sub: NO_SKILLS_USER_ID }),
-    }));
-    vi.doMock('../src/lib/supabase', () => ({
-      supabase: {
-        from: (table: string) => {
-          if (table === 'profile_skills') {
-            return {
-              select: (_: string) => ({
-                eq: (_col: string, val: string) => ({
-                  data: [],
-                  error: null,
-                }),
-              }),
-            };
-          }
-          return { select: () => ({ eq: () => ({ data: [], error: null }) }) };
-        },
-      },
-    }));
-    vi.doMock('../src/utils/tokens', () => ({
-      generateAccessToken: (userId: string) => `token-for-${userId}`,
-    }));
-    const mod = await import('../src/app');
-    const appNoSkills = mod.createApp();
-    const res = await request(appNoSkills)
-      .get('/api/profile/skills')
-      .set('Authorization', `Bearer token-for-${NO_SKILLS_USER_ID}`);
-    expect(res.status).toBe(200);
-    expect(Array.isArray(res.body)).toBe(true);
-    expect(res.body.length).toBe(0);
-  });
+	it('401: returns NOT_AUTHENTICATED if JWT is invalid', async () => {
+		mockJwtVerify.mockImplementation(() => { throw new Error('bad token'); });
+		const res = await request(app)
+			.get(route)
+			.set('Authorization', 'Bearer badtoken');
+		expect(res.status).toBe(401);
+		expect(res.body).toEqual({ code: 'NOT_AUTHENTICATED' });
+	});
 
-  it('should dedupe and sort skills alphabetically', async () => {
-    await vi.resetModules();
-    vi.doMock('jsonwebtoken', () => ({
-      verify: () => ({ sub: TEST_USER_ID }),
-    }));
-    vi.doMock('../src/lib/supabase', () => ({
-      supabase: {
-        from: (table: string) => {
-          if (table === 'profile_skills') {
-            return {
-              select: (_: string) => ({
-                eq: (_col: string, val: string) => ({
-                  data: [
-                    { skills: { id: 2, name: 'SQL' } },
-                    { skills: { id: 1, name: 'Python' } },
-                    { skills: { id: 1, name: 'Python' } }, // duplicate
-                    { skills: { id: 3, name: 'C++' } },
-                  ],
-                  error: null,
-                }),
-              }),
-            };
-          }
-          return { select: () => ({ eq: () => ({ data: [], error: null }) }) };
-        },
-      },
-    }));
-    vi.doMock('../src/utils/tokens', () => ({
-      generateAccessToken: (userId: string) => `token-for-${userId}`,
-    }));
-    const mod = await import('../src/app');
-    const appDedupeSort = mod.createApp();
-    const res = await request(appDedupeSort)
-      .get('/api/profile/skills')
-      .set('Authorization', `Bearer token-for-${TEST_USER_ID}`);
-    expect(res.status).toBe(200);
-    expect(res.body).toEqual([
-      { id: 3, name: 'C++' },
-      { id: 1, name: 'Python' },
-      { id: 2, name: 'SQL' },
-    ]);
-  });
+	it('200: returns skills for valid user', async () => {
+		mockJwtVerify.mockReturnValue({ sub: 'user-123' });
+		const res = await request(app)
+			.get(route)
+			.set('Authorization', 'Bearer validtoken');
+		expect(res.status).toBe(200);
+		expect(res.body).toEqual([
+			{ id: 2, name: 'Node.js' },
+			{ id: 1, name: 'React' },
+			{ id: 3, name: 'TypeScript' },
+		]);
+	});
+
+	it('200: deduplicates and sorts skills by name', async () => {
+		// Patch supabase mock for this test only
+		vi.doMock('../src/lib/supabase', () => ({
+			supabase: {
+				from: (table: string) => {
+					if (table === 'profile_skills') {
+						return {
+							select: () => ({
+								eq: () => ({
+									data: [
+										{ skills: { id: 2, name: 'Node.js' } },
+										{ skills: { id: 1, name: 'React' } },
+										{ skills: { id: 3, name: 'TypeScript' } },
+										{ skills: { id: 1, name: 'React' } }, // duplicate
+										{ skills: { id: 2, name: 'Node.js' } }, // duplicate
+									],
+									error: null,
+								}),
+							}),
+						};
+					}
+					return makeSupabaseMock(scenario).from(table);
+				},
+			},
+		}));
+		mockJwtVerify.mockReturnValue({ sub: 'user-123' });
+		app = await buildApp();
+		const res = await request(app)
+			.get(route)
+			.set('Authorization', 'Bearer validtoken');
+		expect(res.status).toBe(200);
+		// Sorted by name, deduped by id
+		expect(res.body).toEqual([
+			{ id: 2, name: 'Node.js' },
+			{ id: 1, name: 'React' },
+			{ id: 3, name: 'TypeScript' },
+		]);
+	});
 });


### PR DESCRIPTION
- implement get /profile/skills
- add bearer token authorization to openapi spec
- fix login to get id from `profiles` table instead of `user_signups`
- split route files
<img width="1684" height="552" alt="image" src="https://github.com/user-attachments/assets/7c38a37d-ebd7-4fae-ac01-55aa82770c84" />
<img width="1294" height="286" alt="image" src="https://github.com/user-attachments/assets/9c46b8d5-fcdf-44fc-8be1-9a9d26a275d8" />

