### PR TITLE
Story 2.16 - List educations

### DIFF
--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -1509,6 +1509,50 @@ paths:
                   value:
                     code: NOT_FOUND
 
+  /profile/educations:
+    get:
+      tags: ["Profile"]
+      summary: List all educations for the authenticated user
+      description: |
+        Returns all educations for the authenticated user, sorted by:
+        endYear DESC NULLS LAST, endMonth DESC NULLS LAST, startYear DESC, startMonth DESC.
+        
+        **Auth:** Bearer token required.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: Successfully fetch all educations
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Education"
+              examples:
+                one_education:
+                  value:
+                    - id: "edu_123"
+                      school: "UNSW"
+                      program: "Bachelor of Engineering"
+                      major: "Software Engineering"
+                      startMonth: 2
+                      startYear: 2022
+                      endMonth: null
+                      endYear: null
+                no_educations:
+                  value: []
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorSimple"
+              examples:
+                not_authenticated:
+                  value:
+                    code: NOT_AUTHENTICATED
+
   /profile/handle:
     patch:
       tags: ["Handles"]
@@ -2305,3 +2349,56 @@ components:
           nullable: true
           description: User's bio or about section
           example: "I ship boring, reliable services."
+
+    Education:
+      type: object
+      required:
+        - id
+        - school
+        - program
+        - major
+        - startMonth
+        - startYear
+      properties:
+        id:
+          type: string
+          description: Unique education record identifier
+          example: "edu_123"
+        school:
+          type: string
+          description: Name of the school
+          example: "UNSW"
+        program:
+          type: string
+          description: Name of the academic program
+          example: "Bachelor of Engineering"
+        major:
+          type: string
+          description: Name of the major
+          example: "Software Engineering"
+        startMonth:
+          type: integer
+          minimum: 1
+          maximum: 12
+          description: Month when the education started
+          example: 2
+        startYear:
+          type: integer
+          minimum: 1900
+          maximum: 2100
+          description: Year when the education started
+          example: 2022
+        endMonth:
+          type: integer
+          nullable: true
+          minimum: 1
+          maximum: 12
+          description: Month when the education ended
+          example: null
+        endYear:
+          type: integer
+          nullable: true
+          minimum: 1900
+          maximum: 2100
+          description: Year when the education ended
+          example: null

--- a/backend/src/routes/profile.routes.ts
+++ b/backend/src/routes/profile.routes.ts
@@ -8,6 +8,7 @@ import {
   getProfileDetails,
   updateProfile,
 } from "../services/profile.service";
+import { getProfileEducations } from "../services/educations.service";
 
 const router = Router();
 
@@ -209,6 +210,32 @@ router.delete("/profile/skills/:id", async (req, res) => {
       return res.status(401).json({ code: "NOT_AUTHENTICATED" });
     }
     console.error("removeSkillFromProfile.error", err);
+    return res.status(500).json({ code: "INTERNAL" });
+  }
+});
+
+// GET  /profile/educations - lists all profile educations
+router.get("/profile/educations", async (req, res) => {
+  // validate access token
+  const accessToken = req.headers.authorization?.split(" ")[1];
+  if (!accessToken) {
+    return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+  }
+  // extract user id from token
+  let userId: string;
+  try {
+    const decoded = jwt.verify(accessToken, process.env.JWT_SECRET!) as any;
+    userId = decoded.sub;
+    if (!userId) throw new Error("No userId in token");
+  } catch {
+    return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+  }
+
+  try {
+    const educations = await getProfileEducations(userId);
+    return res.status(200).json(educations);
+  } catch (err) {
+    console.error("getProfileEducations.error", err);
     return res.status(500).json({ code: "INTERNAL" });
   }
 });

--- a/backend/src/services/educations.service.ts
+++ b/backend/src/services/educations.service.ts
@@ -1,0 +1,54 @@
+import { supabase } from "../lib/supabase";
+
+export interface Education {
+  id: string;
+  school: string;
+  program: string;
+  major: string;
+  startMonth: number;
+  startYear: number;
+  endMonth: number | null;
+  endYear: number | null;
+}
+
+/**
+ * Fetch all educations for a given profile (user) ID.
+ * Sorted by: endYear DESC NULLS LAST, endMonth DESC NULLS LAST, startYear DESC, startMonth DESC
+ * @param profileId The UUID of the profile/user
+ * @returns Array of educations
+ */
+export async function getProfileEducations(profileId: string): Promise<Education[]> {
+  const { data, error } = await supabase
+    .from("educations")
+    .select(`
+      id,
+      start_year,
+      start_month,
+      end_year,
+      end_month,
+      schools!inner(name),
+      programs!inner(name),
+      majors!inner(name)
+    `)
+    .eq("profile_id", profileId)
+    .order("end_year", { ascending: false, nullsFirst: false })
+    .order("end_month", { ascending: false, nullsFirst: false })
+    .order("start_year", { ascending: false })
+    .order("start_month", { ascending: false });
+
+  if (error) {
+    console.error("getProfileEducations.error", error);
+    throw error;
+  }
+
+  return (data || []).map((edu: any) => ({
+    id: edu.id,
+    school: edu.schools?.name || "",
+    program: edu.programs?.name || "",
+    major: edu.majors?.name || "",
+    startMonth: edu.start_month,
+    startYear: edu.start_year,
+    endMonth: edu.end_month,
+    endYear: edu.end_year,
+  }));
+}

--- a/backend/tests/profile-educations.get.test.ts
+++ b/backend/tests/profile-educations.get.test.ts
@@ -1,0 +1,172 @@
+import request from 'supertest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { type Scenario, makeSupabaseMock } from './utils/supabaseMock';
+
+let app: ReturnType<Awaited<typeof import('../src/app')>['createApp']>;
+let scenario: Scenario;
+let educationsData: any[];
+let supabaseError: any;
+
+const mockJwtVerify = vi.fn();
+vi.mock('jsonwebtoken', () => ({
+  default: { verify: mockJwtVerify },
+  verify: mockJwtVerify,
+}));
+
+async function buildApp() {
+  const mod = await import('../src/app');
+  return mod.createApp();
+}
+
+beforeEach(async () => {
+  await vi.resetModules();
+  scenario = {
+    adminUserByEmail: null,
+    adminListUsers: [],
+    activeProfileByEmail: null,
+    activeProfileByZid: null,
+    pendingByEmail: null,
+    pendingByZid: null,
+    expiredByZid: null,
+    expiredByEmail: null,
+    createdSignupId: 'signup-created-1',
+    revivedSignupId: 'signup-revived-1',
+  };
+  
+  educationsData = [
+    {
+      id: 'edu-1',
+      start_year: 2022,
+      start_month: 2,
+      end_year: null,
+      end_month: null,
+      schools: { name: 'UNSW' },
+      programs: { name: 'Bachelor of Engineering' },
+      majors: { name: 'Software Engineering' },
+    },
+    {
+      id: 'edu-2',
+      start_year: 2020,
+      start_month: 7,
+      end_year: 2021,
+      end_month: 12,
+      schools: { name: 'University of Melbourne' },
+      programs: { name: 'Master of Computer Science' },
+      majors: { name: 'Machine Learning' },
+    },
+    {
+      id: 'edu-3',
+      start_year: 2018,
+      start_month: 3,
+      end_year: 2020,
+      end_month: 6,
+      schools: { name: 'Sydney University' },
+      programs: { name: 'Bachelor of Science' },
+      majors: { name: 'Computer Science' },
+    },
+  ];
+  
+  supabaseError = null;
+
+  // Custom supabase mock for educations
+  vi.doMock('../src/lib/supabase', () => ({
+    supabase: {
+      from: (table: string) => {
+        if (table === 'educations') {
+          return {
+            select: (fields: string) => ({
+              eq: (col: string, val: any) => ({
+                order: (field: string, options?: any) => ({
+                  order: (field2: string, options2?: any) => ({
+                    order: (field3: string, options3?: any) => ({
+                      order: (field4: string, options4?: any) => ({
+                        data: supabaseError ? null : educationsData,
+                        error: supabaseError,
+                      }),
+                    }),
+                  }),
+                }),
+              }),
+            }),
+          };
+        }
+        // fallback to default mock
+        return makeSupabaseMock(scenario).from(table);
+      },
+    },
+  }));
+  
+  app = await buildApp();
+});
+
+const route = '/api/profile/educations';
+
+describe('GET /api/profile/educations', () => {
+  it('200: returns educations for valid user', async () => {
+    mockJwtVerify.mockReturnValue({ sub: 'user-123' });
+    const res = await request(app)
+      .get(route)
+      .set('Authorization', 'Bearer validtoken');
+    
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      {
+        id: 'edu-1',
+        school: 'UNSW',
+        program: 'Bachelor of Engineering',
+        major: 'Software Engineering',
+        startMonth: 2,
+        startYear: 2022,
+        endMonth: null,
+        endYear: null,
+      },
+      {
+        id: 'edu-2',
+        school: 'University of Melbourne',
+        program: 'Master of Computer Science',
+        major: 'Machine Learning',
+        startMonth: 7,
+        startYear: 2020,
+        endMonth: 12,
+        endYear: 2021,
+      },
+      {
+        id: 'edu-3',
+        school: 'Sydney University',
+        program: 'Bachelor of Science',
+        major: 'Computer Science',
+        startMonth: 3,
+        startYear: 2018,
+        endMonth: 6,
+        endYear: 2020,
+      },
+    ]);
+  });
+  
+  it('200: returns empty array when user has no educations', async () => {
+    educationsData = [];
+    mockJwtVerify.mockReturnValue({ sub: 'user-no-educations' });
+    
+    const res = await request(app)
+      .get(route)
+      .set('Authorization', 'Bearer validtoken');
+    
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it('401 NOT_AUTHENTICATED: no Authorization header', async () => {
+    const res = await request(app).get(route);
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ code: 'NOT_AUTHENTICATED' });
+  });
+
+  it('401 NOT_AUTHENTICATED: Authorization header is invalid', async () => {
+    mockJwtVerify.mockImplementation(() => { throw new Error('bad token'); });
+    const res = await request(app)
+      .get(route)
+      .set('Authorization', 'Bearer badtoken');
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ code: 'NOT_AUTHENTICATED' });
+  });
+});


### PR DESCRIPTION
Features implemented:

- Lists all education records of an authorized user

Files modified:

- educations.services.ts - Added getProfileEducations function
- profile.routes.ts - Added GET /profile/educations route
- openapi.yaml - Added complete API documentation

Files added:

- profile-educations.get.test.ts

OpenAPI docs:
<img width="2179" height="1376" alt="image" src="https://github.com/user-attachments/assets/a9240c69-70b5-4751-854e-9324b1277247" />
(currently returns empty array as add education route is not implemented yet)
Tests:
All tests:
<img width="1245" height="152" alt="image" src="https://github.com/user-attachments/assets/ac783000-c328-46ea-8304-abfe94a5d5b8" />
 List education test:
<img width="1217" height="354" alt="image" src="https://github.com/user-attachments/assets/00261970-aa23-47b2-a322-a8cadf049ff5" />
