### PR TITLE
Story 2.17 - Add education to profile

### DIFF
--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -1553,6 +1553,79 @@ paths:
                   value:
                     code: NOT_AUTHENTICATED
 
+    post:
+      tags: ["Profile"]
+      summary: Add an education to the authenticated user's profile
+      description: |
+        Creates a new education record for the authenticated user. 
+        
+        **Validation:**
+        - `school`: Required, 1-30 characters
+        - `startMonth`: Required, 1-12
+        - `startYear`: Required, 1900-2100
+        - `endMonth`, `endYear`: Both must be provided or both must be null
+        - End date must be same as or after start date
+        
+        **Auth:** Bearer token required.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AddEducationRequest"
+            examples:
+              complete_education:
+                summary: Current student (no end date)
+                value:
+                  school: "UNSW"
+                  program: "Bachelor of Engineering"
+                  major: "Software Engineering"
+                  startMonth: 2
+                  startYear: 2022
+                  endMonth: 2
+                  endYear: 2026
+      responses:
+        "201":
+          description: Education added successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [success, id]
+                properties:
+                  success:
+                    type: boolean
+                    example: true
+                  id:
+                    type: string
+                    description: Unique education record identifier
+                    example: "edu_456"
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ValidationError"
+              examples:
+                validation_error:
+                  value:
+                    code: VALIDATION_ERROR
+                    details:
+                      school: ["Required"]
+                      endMonth: ["If either endMonth or endYear is provided, both must be present"]
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorSimple"
+              examples:
+                not_authenticated:
+                  value:
+                    code: NOT_AUTHENTICATED
+
   /profile/handle:
     patch:
       tags: ["Handles"]
@@ -2349,6 +2422,58 @@ components:
           nullable: true
           description: User's bio or about section
           example: "I ship boring, reliable services."
+
+    AddEducationRequest:
+      type: object
+      required:
+        - school
+        - program
+        - major
+        - startMonth
+        - startYear
+      properties:
+        school:
+          type: string
+          minLength: 1
+          maxLength: 30
+          description: Name of the school
+          example: "UNSW"
+        program:
+          type: string
+          minLength: 1
+          description: Name of the academic program
+          example: "Bachelor of Engineering"
+        major:
+          type: string
+          minLength: 1
+          description: Name of the major
+          example: "Software Engineering"
+        startMonth:
+          type: integer
+          minimum: 1
+          maximum: 12
+          description: Month when the education started
+          example: 2
+        startYear:
+          type: integer
+          minimum: 1900
+          maximum: 2100
+          description: Year when the education started
+          example: 2022
+        endMonth:
+          type: integer
+          minimum: 1
+          maximum: 12
+          nullable: true
+          description: Month when the education ended
+          example: null
+        endYear:
+          type: integer
+          minimum: 1900
+          maximum: 2100
+          nullable: true
+          description: Year when the education ended
+          example: null
 
     Education:
       type: object

--- a/backend/src/routes/profile.routes.ts
+++ b/backend/src/routes/profile.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from "express";
 import jwt from "jsonwebtoken";
-import { HandleSchema, UpdateProfileSchema } from "../validation/profile.schemas";
+import { AddEducationSchema, HandleSchema, UpdateProfileSchema } from "../validation/profile.schemas";
 import { getProfileSkills, addSkillToProfile, removeSkillFromProfile } from "../services/skills.service";
 import {
   isHandleAvailable,
@@ -8,7 +8,7 @@ import {
   getProfileDetails,
   updateProfile,
 } from "../services/profile.service";
-import { getProfileEducations } from "../services/educations.service";
+import { addEducationToProfile, getProfileEducations } from "../services/educations.service";
 
 const router = Router();
 
@@ -236,6 +236,44 @@ router.get("/profile/educations", async (req, res) => {
     return res.status(200).json(educations);
   } catch (err) {
     console.error("getProfileEducations.error", err);
+    return res.status(500).json({ code: "INTERNAL" });
+  }
+});
+
+// POST  /profile/educations - add an education for a profile
+router.post("/profile/educations", async (req, res) => {
+  // validate access token
+  const accessToken = req.headers.authorization?.split(" ")[1];
+  if (!accessToken) {
+    return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+  }
+  // extract user id from token
+  let userId: string;
+  try {
+    const decoded = jwt.verify(accessToken, process.env.JWT_SECRET!) as any;
+    userId = decoded.sub;
+    if (!userId) throw new Error("No userId in token");
+  } catch {
+    return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+  }
+
+  // Validate request body
+  const parsed = AddEducationSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ 
+      code: "VALIDATION_ERROR", 
+      details: parsed.error.flatten().fieldErrors 
+    });
+  }
+
+  try {
+    const educationId = await addEducationToProfile(userId, parsed.data);
+    return res.status(201).json({ success: true, id: educationId });
+  } catch (err: any) {
+    if (err?.code === "VALIDATION_ERROR") {
+      return res.status(400).json({ code: "VALIDATION_ERROR" });
+    }
+    console.error("addEducation.error", err);
     return res.status(500).json({ code: "INTERNAL" });
   }
 });

--- a/backend/src/services/lookups.service.ts
+++ b/backend/src/services/lookups.service.ts
@@ -5,7 +5,7 @@ const clean = (s: string | null | undefined) =>
 
 /** Upsert a single-row lookup by case-insensitive name, return its id. */
 async function upsertByName(
-  table: 'programs' | 'majors',
+  table: 'programs' | 'majors' | 'schools',
   name: string
 ): Promise<number> {
   const label = name.trim().replace(/\s+/g, ' ');
@@ -29,4 +29,9 @@ export async function ensureProgramId(name?: string | null) {
 export async function ensureMajorId(name?: string | null) {
   if (!clean(name)) return null;
   return upsertByName('majors', name!);
+}
+
+export async function ensureSchoolId(name?: string | null) {
+  if (!clean(name)) return null;
+  return upsertByName('schools', name!);
 }

--- a/backend/src/validation/profile.schemas.ts
+++ b/backend/src/validation/profile.schemas.ts
@@ -27,5 +27,35 @@ export const UpdateProfileSchema = z.object({
   path: ["yearGrad"]
 });
 
+export const AddEducationSchema = z.object({
+  school: z.string().min(1).max(30),
+  program: z.string().min(1),
+  major: z.string().min(1),
+  startMonth: z.number().int().min(1).max(12),
+  startYear: z.number().int().min(1900).max(2100),
+  endMonth: z.number().int().min(1).max(12).nullable(),
+  endYear: z.number().int().min(1900).max(2100).nullable(),
+}).refine((data) => {
+  if (data.endMonth !== null && data.endYear === null) return false;
+  if (data.endYear !== null && data.endMonth === null) return false;
+  return true;
+}, {
+  message: "If either endMonth or endYear is provided, both must be present",
+  path: ["endMonth"]
+}).refine((data) => {
+  // Validate that endYear is equal or after startYear if both are provided
+  if (data.endYear !== null && data.endMonth !== null) {
+    // If end year is before start year, invalid
+    if (data.endYear < data.startYear) return false;
+    // If same year, end month must be >= start month
+    if (data.endYear === data.startYear && data.endMonth < data.startMonth) return false;
+  }
+  return true;
+}, {
+  message: "End date must be the same as or after start date",
+  path: ["endYear"]
+})
+
 export type HandleInput = z.infer<typeof HandleSchema>;
 export type UpdateProfileInput = z.infer<typeof UpdateProfileSchema>;
+export type AddEducationInput = z.infer<typeof AddEducationSchema>;

--- a/backend/tests/profile-educations.post.test.ts
+++ b/backend/tests/profile-educations.post.test.ts
@@ -1,0 +1,479 @@
+import request from 'supertest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { type Scenario, makeSupabaseMock } from './utils/supabaseMock';
+
+let app: ReturnType<Awaited<typeof import('../src/app')>['createApp']>;
+let scenario: Scenario;
+
+let lookupCalls: {
+  schools: Array<{ name: string; returnId: number }>;
+  programs: Array<{ name: string; returnId: number }>;
+  majors: Array<{ name: string; returnId: number }>;
+} = {
+  schools: [],
+  programs: [],
+  majors: [],
+};
+
+let educationInserts: any[] = [];
+
+const mockJwtVerify = vi.fn();
+vi.mock('jsonwebtoken', () => ({
+  default: { verify: mockJwtVerify },
+  verify: mockJwtVerify,
+}));
+
+async function buildApp() {
+  const mod = await import('../src/app');
+  return mod.createApp();
+}
+
+beforeEach(async () => {
+  await vi.resetModules();
+  
+  scenario = {
+    adminUserByEmail: null,
+    adminListUsers: [],
+    activeProfileByEmail: null,
+    activeProfileByZid: null,
+    pendingByEmail: null,
+    pendingByZid: null,
+    expiredByZid: null,
+    expiredByEmail: null,
+    createdSignupId: 'signup-created-1',
+    revivedSignupId: 'signup-revived-1',
+  };
+  
+  lookupCalls = { schools: [], programs: [], majors: [] };
+  educationInserts = [];
+
+  // Mock supabase
+  vi.doMock('../src/lib/supabase', () => ({
+    supabase: {
+      from: (table: string) => {
+        if (table === 'schools') {
+          return {
+            select: () => ({
+              eq: (col: string, val: string) => ({
+                maybeSingle: async () => {
+                  const existing = lookupCalls.schools.find(s => s.name === val);
+                  if (existing) {
+                    return { data: { id: existing.returnId, name: val }, error: null };
+                  }
+                  return { data: null, error: null };
+                }
+              })
+            }),
+            insert: (data: any) => ({
+              select: () => ({
+                single: async () => {
+                  const newId = lookupCalls.schools.length + 1;
+                  lookupCalls.schools.push({ name: data.name, returnId: newId });
+                  return { data: { id: newId, name: data.name }, error: null };
+                }
+              })
+            }),
+            upsert: (data: any, options?: any) => ({
+              select: () => ({
+                single: async () => {
+                  // Clean name like the service does
+                  const cleanName = data.name.trim().replace(/\s+/g, ' ');
+                  
+                  // Check if already exists (case insensitive)
+                  const existing = lookupCalls.schools.find(s => 
+                    s.name.toLowerCase() === cleanName.toLowerCase()
+                  );
+                  
+                  if (existing) {
+                    return { data: { id: existing.returnId }, error: null };
+                  }
+                  
+                  // Create new entry
+                  const newId = lookupCalls.schools.length + 1;
+                  lookupCalls.schools.push({ name: cleanName, returnId: newId });
+                  return { data: { id: newId }, error: null };
+                }
+              })
+            })
+          };
+        }
+        
+        if (table === 'programs') {
+          return {
+            select: () => ({
+              eq: (col: string, val: string) => ({
+                maybeSingle: async () => {
+                  const existing = lookupCalls.programs.find(p => p.name === val);
+                  if (existing) {
+                    return { data: { id: existing.returnId, name: val }, error: null };
+                  }
+                  return { data: null, error: null };
+                }
+              })
+            }),
+            insert: (data: any) => ({
+              select: () => ({
+                single: async () => {
+                  const newId = lookupCalls.programs.length + 100;
+                  lookupCalls.programs.push({ name: data.name, returnId: newId });
+                  return { data: { id: newId, name: data.name }, error: null };
+                }
+              })
+            }),
+            upsert: (data: any, options?: any) => ({
+              select: () => ({
+                single: async () => {
+                  const cleanName = data.name.trim().replace(/\s+/g, ' ');
+                  
+                  const existing = lookupCalls.programs.find(p => 
+                    p.name.toLowerCase() === cleanName.toLowerCase()
+                  );
+                  
+                  if (existing) {
+                    return { data: { id: existing.returnId }, error: null };
+                  }
+                  
+                  const newId = lookupCalls.programs.length + 100;
+                  lookupCalls.programs.push({ name: cleanName, returnId: newId });
+                  return { data: { id: newId }, error: null };
+                }
+              })
+            })
+          };
+        }
+        
+        if (table === 'majors') {
+          return {
+            select: () => ({
+              eq: (col: string, val: string) => ({
+                maybeSingle: async () => {
+                  const existing = lookupCalls.majors.find(m => m.name === val);
+                  if (existing) {
+                    return { data: { id: existing.returnId, name: val }, error: null };
+                  }
+                  return { data: null, error: null };
+                }
+              })
+            }),
+            insert: (data: any) => ({
+              select: () => ({
+                single: async () => {
+                  const newId = lookupCalls.majors.length + 200;
+                  lookupCalls.majors.push({ name: data.name, returnId: newId });
+                  return { data: { id: newId, name: data.name }, error: null };
+                }
+              })
+            }),
+            upsert: (data: any, options?: any) => ({
+              select: () => ({
+                single: async () => {
+                  const cleanName = data.name.trim().replace(/\s+/g, ' ');
+                  
+                  const existing = lookupCalls.majors.find(m => 
+                    m.name.toLowerCase() === cleanName.toLowerCase()
+                  );
+                  
+                  if (existing) {
+                    return { data: { id: existing.returnId }, error: null };
+                  }
+                  
+                  const newId = lookupCalls.majors.length + 200;
+                  lookupCalls.majors.push({ name: cleanName, returnId: newId });
+                  return { data: { id: newId }, error: null };
+                }
+              })
+            })
+          };
+        }
+        
+        if (table === 'educations') {
+          return {
+            insert: (data: any) => ({
+              select: () => ({
+                single: async () => {
+                  const newId = educationInserts.length + 1;
+                  const inserted = { ...data, id: newId };
+                  educationInserts.push(inserted);
+                  return { data: { id: newId }, error: null };
+                }
+              })
+            })
+          };
+        }
+        
+        return makeSupabaseMock(scenario).from(table);
+      }
+    }
+  }));
+
+  app = await buildApp();
+});
+
+const route = '/api/profile/educations';
+
+describe('POST /api/profile/educations', () => {
+  it('201: creates education successfully', async () => {
+      mockJwtVerify.mockReturnValue({ sub: 'user-123' });
+
+      const payload = {
+        school: 'University of Melbourne',
+        program: 'Master of Computer Science',
+        major: 'Machine Learning',
+        startMonth: 7,
+        startYear: 2020,
+        endMonth: 12,
+        endYear: 2021
+      };
+
+      const res = await request(app)
+        .post(route)
+        .set('Authorization', 'Bearer validtoken')
+        .send(payload);
+
+      expect(res.status).toBe(201);
+      expect(res.body).toEqual({
+        success: true,
+        id: 'edu_1'
+      });
+
+      // Verify data was properly stored
+      expect(educationInserts[0]).toMatchObject({
+        profile_id: 'user-123',
+        school_id: 1,
+        program_id: 100,
+        major_id: 200,
+        start_month: 7,
+        start_year: 2020,
+        end_month: 12,
+        end_year: 2021
+    });
+  });
+  it('401 NOT_AUTHENTICATED: no Authorization header', async () => {
+    const payload = {
+      school: 'UNSW',
+      program: 'Bachelor of Engineering',
+      major: 'Software Engineering',
+      startMonth: 2,
+      startYear: 2022,
+      endMonth: null,
+      endYear: null
+    };
+
+    const res = await request(app)
+      .post(route)
+      .send(payload);
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ code: 'NOT_AUTHENTICATED' });
+  });
+
+  it('401 NOT_AUTHENTICATED: invalid header token', async () => {
+    mockJwtVerify.mockImplementation(() => {
+      throw new Error('Invalid token');
+    });
+
+    const payload = {
+      school: 'UNSW',
+      program: 'Bachelor of Engineering',
+      major: 'Software Engineering',
+      startMonth: 2,
+      startYear: 2022,
+      endMonth: null,
+      endYear: null
+    };
+
+    const res = await request(app)
+      .post(route)
+      .set('Authorization', 'Bearer invalidtoken')
+      .send(payload);
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ code: 'NOT_AUTHENTICATED' });
+  });
+
+  describe('Validation Errors', () => {
+    beforeEach(() => {
+      mockJwtVerify.mockReturnValue({ sub: 'user-123' });
+    });
+
+    it('400 VALIDATION_ERROR: school too long (> 30 chars)', async () => {
+      const payload = {
+        school: 'A'.repeat(31), // 31 characters
+        program: 'Bachelor of Engineering',
+        major: 'Software Engineering',
+        startMonth: 2,
+        startYear: 2022,
+        endMonth: null,
+        endYear: null
+      };
+
+      const res = await request(app)
+        .post(route)
+        .set('Authorization', 'Bearer validtoken')
+        .send(payload);
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('400 VALIDATION_ERROR: invalid startMonth (< 1)', async () => {
+      const payload = {
+        school: 'UNSW',
+        program: 'Bachelor of Engineering',
+        major: 'Software Engineering',
+        startMonth: 0,
+        startYear: 2022,
+        endMonth: null,
+        endYear: null
+      };
+
+      const res = await request(app)
+        .post(route)
+        .set('Authorization', 'Bearer validtoken')
+        .send(payload);
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('400 VALIDATION_ERROR: invalid startMonth (> 12)', async () => {
+      const payload = {
+        school: 'UNSW',
+        program: 'Bachelor of Engineering',
+        major: 'Software Engineering',
+        startMonth: 13,
+        startYear: 2022,
+        endMonth: null,
+        endYear: null
+      };
+
+      const res = await request(app)
+        .post(route)
+        .set('Authorization', 'Bearer validtoken')
+        .send(payload);
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('400 VALIDATION_ERROR: invalid startYear (< 1900)', async () => {
+      const payload = {
+        school: 'UNSW',
+        program: 'Bachelor of Engineering',
+        major: 'Software Engineering',
+        startMonth: 2,
+        startYear: 1899,
+        endMonth: null,
+        endYear: null
+      };
+
+      const res = await request(app)
+        .post(route)
+        .set('Authorization', 'Bearer validtoken')
+        .send(payload);
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('400 VALIDATION_ERROR: invalid startYear (> 2100)', async () => {
+      const payload = {
+        school: 'UNSW',
+        program: 'Bachelor of Engineering',
+        major: 'Software Engineering',
+        startMonth: 2,
+        startYear: 2101,
+        endMonth: null,
+        endYear: null
+      };
+
+      const res = await request(app)
+        .post(route)
+        .set('Authorization', 'Bearer validtoken')
+        .send(payload);
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('400 VALIDATION_ERROR: endMonth provided but endYear is null', async () => {
+      const payload = {
+        school: 'UNSW',
+        program: 'Bachelor of Engineering',
+        major: 'Software Engineering',
+        startMonth: 2,
+        startYear: 2022,
+        endMonth: 6,
+        endYear: null
+      };
+
+      const res = await request(app)
+        .post(route)
+        .set('Authorization', 'Bearer validtoken')
+        .send(payload);
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('400 VALIDATION_ERROR: endYear provided but endMonth is null', async () => {
+      const payload = {
+        school: 'UNSW',
+        program: 'Bachelor of Engineering',
+        major: 'Software Engineering',
+        startMonth: 2,
+        startYear: 2022,
+        endMonth: null,
+        endYear: 2024
+      };
+
+      const res = await request(app)
+        .post(route)
+        .set('Authorization', 'Bearer validtoken')
+        .send(payload);
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('400 VALIDATION_ERROR: endYear before startYear', async () => {
+      const payload = {
+        school: 'UNSW',
+        program: 'Bachelor of Engineering',
+        major: 'Software Engineering',
+        startMonth: 2,
+        startYear: 2022,
+        endMonth: 6,
+        endYear: 2021
+      };
+
+      const res = await request(app)
+        .post(route)
+        .set('Authorization', 'Bearer validtoken')
+        .send(payload);
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('VALIDATION_ERROR');
+    });
+
+    it('400 VALIDATION_ERROR: same year but endMonth before startMonth', async () => {
+      const payload = {
+        school: 'UNSW',
+        program: 'Bachelor of Engineering',
+        major: 'Software Engineering',
+        startMonth: 6,
+        startYear: 2022,
+        endMonth: 3,
+        endYear: 2022
+      };
+
+      const res = await request(app)
+        .post(route)
+        .set('Authorization', 'Bearer validtoken')
+        .send(payload);
+
+      expect(res.status).toBe(400);
+      expect(res.body.code).toBe('VALIDATION_ERROR');
+    });
+  });
+});


### PR DESCRIPTION
Features implemented:

- Add an education record for an authorized user

Files modified:

- educations.services.ts - Added addEducationToProfile function

- profile.routes.ts - Added POST /profile/educations route
- lookups.service.ts - Added ensureSchoolId function
- profile.schemas.ts - Made AddEducationSchema

- openapi.yaml - Added complete API documentation

Files added:

- profile-educations.post.test.ts

OpenAPI docs:
![WhatsApp Image 2025-09-14 at 21 02 18_b44d868c](https://github.com/user-attachments/assets/b64c6234-3dd4-452d-ba54-0e39d8daecc1)
![WhatsApp Image 2025-09-14 at 21 02 25_d44728c2](https://github.com/user-attachments/assets/6bf29802-eeae-43be-832b-5c2b6bf2c8e8)
Correct data modification (correctly listed):
![WhatsApp Image 2025-09-14 at 21 02 41_bbf8fc0e](https://github.com/user-attachments/assets/9cc94ace-e36d-4376-80a3-d7dad196eb59)
All tests:
![WhatsApp Image 2025-09-14 at 22 58 45_f45516c5](https://github.com/user-attachments/assets/61acc379-ca38-40a7-95eb-89e4cb6d05f7)
Test for this feature:
![WhatsApp Image 2025-09-14 at 22 59 24_ab822631](https://github.com/user-attachments/assets/7532eccb-7eb3-4c9b-8942-b6e54d638c40)
