### PR TITLE
Story 2.18 & 2.19 - Update education & delete education

### DIFF
--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -1626,6 +1626,87 @@ paths:
                   value:
                     code: NOT_AUTHENTICATED
 
+  /profile/educations/{id}:
+    patch:
+      tags: ["Profile"]
+      summary: Update an education record
+      description: |
+        Updates an existing education record for the authenticated user.
+        Only provided fields are updated (partial update).
+        
+        **Validation:**
+        - `school`: 1-30 characters
+        - `program`: valid string
+        - `major`: valid string
+        - `endMonth`, `endYear`: Both must be provided or both must be null
+        - End date must be same as or after start date if both start and end are provided
+        
+        **Auth:** Bearer token required.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Education record ID to update
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateEducationRequest"
+            examples:
+              complete_update:
+                value:
+                  school: "University of Sydney"
+                  program: "Master of Information Technology"
+                  major: "Cybersecurity"
+                  endMonth: 12
+                  endYear: 2024
+      responses:
+        "200":
+          description: Education updated successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessOnly"
+              examples:
+                success:
+                  value:
+                    success: true
+        "400":
+          description: Validation error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorSimple"
+              examples:
+                validation_error:
+                  value:
+                    code: VALIDATION_ERROR
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorSimple"
+              examples:
+                not_authenticated:
+                  value:
+                    code: NOT_AUTHENTICATED
+        "404":
+          description: Education record not found or not owned by user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorSimple"
+              examples:
+                not_found:
+                  value:
+                    code: NOT_FOUND
+
   /profile/social-links:
     patch:
       tags: ["Profile"]
@@ -2519,6 +2600,35 @@ components:
           nullable: true
           description: Year when the education ended
           example: null
+
+    UpdateEducationRequest:
+      type: object
+      properties:
+        school:
+          type: string
+          minLength: 1
+          maxLength: 30
+          description: Name of the school
+        program:
+          type: string
+          minLength: 1
+          description: Name of the academic program
+        major:
+          type: string
+          minLength: 1
+          description: Name of the major
+        endMonth:
+          type: integer
+          minimum: 1
+          maximum: 12
+          nullable: true
+          description: Month when the education ended
+        endYear:
+          type: integer
+          minimum: 1900
+          maximum: 2100
+          nullable: true
+          description: Year when the education ended
 
     Education:
       type: object

--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -7,7 +7,7 @@ info:
     passwordless resume tokens, login, and token refresh.
 
 servers:
-  - url: http://localhost:5000/docs
+  - url: http://localhost:5000/api
     description: Local dev
 
 security:
@@ -1704,6 +1704,55 @@ paths:
                 $ref: "#/components/schemas/ErrorSimple"
               examples:
                 not_found:
+                  value:
+                    code: NOT_FOUND
+    delete:
+      tags: ["Profile"]
+      summary: Delete an education record
+      description: |
+        Deletes an education record owned by the authenticated user.
+        
+        **Idempotent:** Returns 200 if education is already deleted.
+        
+        **Auth:** Bearer token required.
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: Education record ID to delete
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Education deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessOnly"
+              examples:
+                success:
+                  value:
+                    success: true
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorSimple"
+              examples:
+                not_authenticated:
+                  value:
+                    code: NOT_AUTHENTICATED
+        "404":
+          description: Not found / not owned
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorSimple"
+              examples:
+                not_authenticated:
                   value:
                     code: NOT_FOUND
 

--- a/backend/src/routes/profile.routes.ts
+++ b/backend/src/routes/profile.routes.ts
@@ -25,7 +25,7 @@ import {
   addEducationToProfile,
   getProfileEducations,
   updateProfileEducation,
-  deleteEducation
+  deleteProfileEducation
 } from "../services/educations.service";
 import {
   getProfileExperiences,
@@ -346,16 +346,15 @@ router.patch("/profile/educations/:id", async (req, res) => {
   const userId = authenticateUser(req, res);
   if (!userId) return;
 
+  const eduId = String(req.params.id || '').trim();
+  if (!eduId) {
+    return res.status(404).json({ code: 'NOT_FOUND' });
+  }
+
   // Validate request body
   const parsed = UpdateEducationSchema.safeParse(req.body);
   if (!parsed.success) {
     return res.status(400).json({ code: "VALIDATION_ERROR" });
-  }
-
-  // Get education id
-  const eduId = req.params.id;
-  if (!eduId) {
-    return res.status(404).json({ code: "NOT_FOUND" });
   }
 
   try {
@@ -384,7 +383,7 @@ router.delete('/profile/educations/:id', async (req, res) => {
   }
 
   try {
-    const result = await deleteEducation(userId, eduId);
+    const result = await deleteProfileEducation(userId, eduId);
 
     if (result === 'NOT_OWNED') {
       return res.status(404).json({ code: 'NOT_FOUND' });

--- a/backend/src/services/educations.service.ts
+++ b/backend/src/services/educations.service.ts
@@ -170,7 +170,7 @@ export async function updateProfileEducation(profileId: string, eduId: string, u
  * - 'NOT_OWNED' → row exists but belongs to someone else
  * - 'NOOP'      → row does not exist
  */
-export async function deleteEducation(
+export async function deleteProfileEducation(
   profileId: string,
   eduId: string
 ): Promise<'DELETED' | 'NOT_OWNED' | 'NOOP'> {

--- a/backend/src/services/educations.service.ts
+++ b/backend/src/services/educations.service.ts
@@ -1,5 +1,5 @@
 import { supabase } from "../lib/supabase";
-import { AddEducationInput } from "../validation/profile.schemas";
+import { AddEducationInput, UpdateEducationInput } from "../validation/profile.schemas";
 import { ensureProgramId, ensureMajorId, ensureSchoolId } from "./lookups.service";
 
 export interface Education {
@@ -93,4 +93,72 @@ export async function addEducationToProfile(profileId: string, eduInput: AddEduc
   }
 
   return `edu_${data.id}`;
+}
+
+export async function updateProfileEducation(profileId: string, eduId: string, updates: UpdateEducationInput): Promise<void> {
+  // First, check if the education exists and belongs to the user
+  const { data: existingEducation, error: fetchError } = await supabase
+    .from('educations')
+    .select('id, profile_id, start_month, start_year')
+    .eq('id', eduId.replace('edu_', ''))
+    .eq('profile_id', profileId)
+    .single();
+
+  if (fetchError || !existingEducation) {
+    throw { code: "NOT_FOUND" };
+  }
+
+  // Validate date logic if endMonth/endYear are being updated
+  if ((updates.endMonth !== undefined || updates.endYear !== undefined) && 
+      updates.endMonth !== null && updates.endYear !== null) {
+    const startYear = existingEducation.start_year;
+    const startMonth = existingEducation.start_month;
+    
+    // If end year is before start year, invalid
+    if (updates.endYear !== undefined && updates.endYear < startYear) {
+      throw { code: "VALIDATION_ERROR" };
+    }
+    // If same year, end month must be >= start month
+    if (updates.endYear !== undefined && updates.endMonth !== undefined && 
+        updates.endYear === startYear && updates.endMonth < startMonth) {
+      throw { code: "VALIDATION_ERROR" };
+    }
+  }
+
+  // Build the update object
+  const updateData: Record<string, any> = {};
+
+  if (updates.school !== undefined) {
+    // Lookup school (create if needed)
+    const schoolId = await ensureSchoolId(updates.school);
+    if (schoolId !== null) updateData.school_id = schoolId;
+  }
+
+  if (updates.program !== undefined) {
+    // Lookup program (create if needed)
+    const programId = await ensureProgramId(updates.program);
+    if (programId !== null) updateData.program_id = programId;
+  }
+
+  if (updates.major !== undefined) {
+    // Lookup major (create if needed)
+    const majorId = await ensureMajorId(updates.major);
+    if (majorId !== null) updateData.major_id = majorId;
+  }
+
+  if (updates.endYear !== undefined) updateData.end_year = updates.endYear;
+  if (updates.endMonth !== undefined) updateData.end_month = updates.endMonth;
+
+  // Only proceed if there are updates to apply
+  if (Object.keys(updateData).length === 0) {
+    return;
+  }
+
+  const { error } = await supabase
+    .from('educations')
+    .update(updateData)
+    .eq('id', eduId.replace('edu_', ''))
+    .eq('profile_id', profileId);
+
+  if (error) throw error;
 }

--- a/backend/src/validation/profile.schemas.ts
+++ b/backend/src/validation/profile.schemas.ts
@@ -77,10 +77,26 @@ export const AddEducationSchema = z.object({
 }, {
   message: "End date must be the same as or after start date",
   path: ["endYear"]
-})
+});
+
+export const UpdateEducationSchema = z.object({
+  school: z.string().min(1).max(30).optional(),
+  program: z.string().min(1).optional(),
+  major: z.string().min(1).optional(),
+  endMonth: z.number().int().min(1).max(12).nullable().optional(),
+  endYear: z.number().int().min(1900).max(2100).nullable().optional(),
+}).refine((data) => {
+  if (data.endMonth !== null && data.endYear === null) return false;
+  if (data.endYear !== null && data.endMonth === null) return false;
+  return true;
+}, {
+  message: "If either endMonth or endYear is provided, both must be present",
+  path: ["endMonth"]
+});
 
 export type HandleInput = z.infer<typeof HandleSchema>;
 export type UpdateProfileInput = z.infer<typeof UpdateProfileSchema>;
 export type SocialLinksInput = z.infer<typeof SocialLinksSchema>;
 export type UpdateSocialLinksInput = z.infer<typeof UpdateSocialLinksSchema>;
 export type AddEducationInput = z.infer<typeof AddEducationSchema>;
+export type UpdateEducationInput = z.infer<typeof UpdateEducationSchema>;

--- a/backend/tests/profile-educations.delete.test.ts
+++ b/backend/tests/profile-educations.delete.test.ts
@@ -1,0 +1,150 @@
+// tests/profile-educations.delete.test.ts
+import request from 'supertest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+let app: ReturnType<Awaited<typeof import('../src/app')>['createApp']>;
+
+// In-memory "DB"
+type EduRow = {
+  id: string;
+  profile_id: string;
+};
+
+let educations: EduRow[] = [];
+
+// jwt.verify mock
+const mockJwtVerify = vi.fn();
+vi.mock('jsonwebtoken', () => ({
+  default: { verify: mockJwtVerify },
+  verify: mockJwtVerify,
+}));
+
+async function buildApp() {
+  const mod = await import('../src/app');
+  return mod.createApp();
+}
+
+beforeEach(async () => {
+  vi.resetModules();
+  educations = [
+    { id: '1', profile_id: 'profile-123' },
+    { id: '2', profile_id: 'someone-else' },
+  ];
+
+  // Reapply jwt mock after reset
+  vi.doMock('jsonwebtoken', () => ({
+    default: { verify: mockJwtVerify },
+    verify: mockJwtVerify,
+  }));
+
+  // Supabase mock for educations
+  vi.doMock('../src/lib/supabase', () => ({
+    supabase: {
+      from: (table: string) => {
+        if (table !== 'educations') {
+          // small stub for any accidental other table access
+          return {
+            select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }),
+            delete: () => ({ eq: () => ({ eq: async () => ({ data: null, error: null }) }) }),
+          };
+        }
+
+        const api = {
+          select: (_cols: string) => ({
+            eq: (key: string, val: any) => ({
+              maybeSingle: async () => {
+                // Handle both raw ID and edu_ prefixed ID
+                const cleanId = String(val).replace('edu_', '');
+                const row = educations.find(r => r.id === cleanId) || null;
+                return { data: row ? { id: row.id, profile_id: row.profile_id } : null, error: null };
+              },
+            }),
+          }),
+          delete: () => ({
+            eq: (key1: string, val1: any) => ({
+              eq: async (key2: string, val2: any) => {
+                // Expect chaining: .delete().eq('id', id).eq('profile_id', profileId)
+                const cleanId = String(val1).replace('edu_', '');
+                const before = educations.length;
+                educations = educations.filter(
+                  r => !(r.id === cleanId && r.profile_id === String(val2))
+                );
+                const after = educations.length;
+                return { data: before !== after ? { id: cleanId } : null, error: null };
+              },
+            }),
+          }),
+        };
+        return api as any;
+      },
+    },
+  }));
+
+  app = await buildApp();
+  mockJwtVerify.mockReset();
+});
+
+const route = '/api/profile/educations';
+
+describe('DELETE /api/profile/educations/:id', () => {
+  it('200 success: owned education removed', async () => {
+    mockJwtVerify.mockReturnValue({ sub: 'profile-123' });
+  
+    const res = await request(app)
+      .delete(`${route}/1`)
+      .set('Authorization', 'Bearer ok');
+  
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+    expect(educations.some(e => e.id === '1')).toBe(false);
+  });
+
+  it('200 idempotent: owned education removed twice', async () => {
+    mockJwtVerify.mockReturnValue({ sub: 'profile-123' });
+
+    let res = await request(app)
+      .delete(`${route}/1`)
+      .set('Authorization', 'Bearer ok');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+    
+    res = await request(app)
+      .delete(`${route}/1`)
+      .set('Authorization', 'Bearer ok');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+  });
+
+  it('401 NOT_AUTHENTICATED: no Authorization header', async () => {
+
+    const res = await request(app)
+      .delete(`${route}/1`)
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ code: 'NOT_AUTHENTICATED' });
+  });
+
+  it('401 NOT_AUTHENTICATED: invalid Authorization header', async () => {
+    mockJwtVerify.mockImplementation(() => { throw new Error('bad token'); });
+
+    const res = await request(app)
+      .delete(`${route}/1`)
+      .set('Authorization', 'Bearer badtoken');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ code: 'NOT_AUTHENTICATED' });
+  });
+
+  it('404 NOT_FOUND: education not owned by user', async () => {
+    mockJwtVerify.mockReturnValue({ sub: 'someone-else' });
+  
+    const res = await request(app)
+      .delete(`${route}/1`)
+      .set('Authorization', 'Bearer ok');
+  
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ code: 'NOT_FOUND' });
+  });
+});

--- a/backend/tests/profile-educations.patch.test.ts
+++ b/backend/tests/profile-educations.patch.test.ts
@@ -1,0 +1,309 @@
+import request from 'supertest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { type Scenario, makeSupabaseMock } from './utils/supabaseMock';
+
+let app: ReturnType<Awaited<typeof import('../src/app')>['createApp']>;
+let scenario: Scenario;
+
+let lookupCalls: {
+  schools: Array<{ name: string; returnId: number }>;
+  programs: Array<{ name: string; returnId: number }>;
+  majors: Array<{ name: string; returnId: number }>;
+} = {
+  schools: [],
+  programs: [],
+  majors: [],
+};
+
+let educationUpdates: any[] = [];
+let educationSelects: any[] = [];
+
+const mockJwtVerify = vi.fn();
+vi.mock('jsonwebtoken', () => ({
+  default: { verify: mockJwtVerify },
+  verify: mockJwtVerify,
+}));
+
+async function buildApp() {
+  const mod = await import('../src/app');
+  return mod.createApp();
+}
+
+beforeEach(async () => {
+  await vi.resetModules();
+  
+  scenario = {
+    adminUserByEmail: null,
+    adminListUsers: [],
+    activeProfileByEmail: null,
+    activeProfileByZid: null,
+    pendingByEmail: null,
+    pendingByZid: null,
+    expiredByZid: null,
+    expiredByEmail: null,
+    createdSignupId: 'signup-created-1',
+    revivedSignupId: 'signup-revived-1',
+  };
+  
+  lookupCalls = { schools: [], programs: [], majors: [] };
+  educationUpdates = [];
+  educationSelects = [];
+
+  // Mock supabase
+  vi.doMock('../src/lib/supabase', () => ({
+    supabase: {
+      from: (table: string) => {
+        if (table === 'schools') {
+          return {
+            select: () => ({
+              eq: (col: string, val: any) => {
+                lookupCalls.schools.push({ name: val, returnId: 1 });
+                return { data: [{ id: 1, name: val }], error: null };
+              },
+              single: () => ({ data: null, error: { code: '23505' } }),
+            }),
+            insert: (data: any) => ({
+              select: () => ({
+                single: () => {
+                  const id = lookupCalls.schools.length;
+                  lookupCalls.schools.push({ name: data.name, returnId: id });
+                  return { data: { id, name: data.name }, error: null };
+                }
+              })
+            }),
+            upsert: (data: any) => ({
+              select: () => ({
+                single: () => {
+                  const id = 1;
+                  lookupCalls.schools.push({ name: data.name, returnId: id });
+                  return { data: { id, name: data.name }, error: null };
+                }
+              })
+            }),
+          };
+        }
+        
+        if (table === 'programs') {
+          return {
+            select: () => ({
+              eq: (col: string, val: any) => {
+                lookupCalls.programs.push({ name: val, returnId: 2 });
+                return { data: [{ id: 2, name: val }], error: null };
+              },
+              single: () => ({ data: null, error: { code: '23505' } }),
+            }),
+            insert: (data: any) => ({
+              select: () => ({
+                single: () => {
+                  const id = lookupCalls.programs.length + 10;
+                  lookupCalls.programs.push({ name: data.name, returnId: id });
+                  return { data: { id, name: data.name }, error: null };
+                }
+              })
+            }),
+            upsert: (data: any) => ({
+              select: () => ({
+                single: () => {
+                  const id = 2;
+                  lookupCalls.programs.push({ name: data.name, returnId: id });
+                  return { data: { id, name: data.name }, error: null };
+                }
+              })
+            }),
+          };
+        }
+        
+        if (table === 'majors') {
+          return {
+            select: () => ({
+              eq: (col: string, val: any) => {
+                lookupCalls.majors.push({ name: val, returnId: 3 });
+                return { data: [{ id: 3, name: val }], error: null };
+              },
+              single: () => ({ data: null, error: { code: '23505' } }),
+            }),
+            insert: (data: any) => ({
+              select: () => ({
+                single: () => {
+                  const id = lookupCalls.majors.length + 20;
+                  lookupCalls.majors.push({ name: data.name, returnId: id });
+                  return { data: { id, name: data.name }, error: null };
+                }
+              })
+            }),
+            upsert: (data: any) => ({
+              select: () => ({
+                single: () => {
+                  const id = 3;
+                  lookupCalls.majors.push({ name: data.name, returnId: id });
+                  return { data: { id, name: data.name }, error: null };
+                }
+              })
+            }),
+          };
+        }
+        
+        if (table === 'educations') {
+          return {
+            select: (fields?: string) => ({
+              eq: (col: string, val: any) => {
+                if (col === 'id' && val === '123') {
+                  educationSelects.push({ id: val, col });
+                  return {
+                    eq: (col2: string, val2: any) => ({
+                      single: () => ({
+                        data: { 
+                          id: 123, 
+                          profile_id: val2, 
+                          start_month: 3, 
+                          start_year: 2020 
+                        }, 
+                        error: null 
+                      })
+                    })
+                  };
+                }
+                if (col === 'id' && val === '456') {
+                  educationSelects.push({ id: val, col });
+                  return {
+                    eq: (col2: string, val2: any) => ({
+                      single: () => ({
+                        data: null, 
+                        error: { code: 'PGRST116' }
+                      })
+                    })
+                  };
+                }
+                return {
+                  eq: () => ({
+                    single: () => ({ data: null, error: { code: 'PGRST116' } })
+                  })
+                };
+              }
+            }),
+            update: (data: any) => ({
+              eq: (col: string, val: any) => {
+                educationUpdates.push({ data, col, val });
+                return {
+                  eq: (col2: string, val2: any) => {
+                    educationUpdates[educationUpdates.length - 1].profileCol = col2;
+                    educationUpdates[educationUpdates.length - 1].profileVal = val2;
+                    return { error: null };
+                  }
+                };
+              }
+            }),
+          };
+        }
+      }
+    }
+  }));
+
+  app = await buildApp();
+});
+
+describe('PATCH /profile/educations/:id', () => {
+  it('200: successfully update education with valid data', async () => {
+    mockJwtVerify.mockReturnValue({ sub: 'user-123' });
+
+    const response = await request(app)
+      .patch('/api/profile/educations/edu_123')
+      .set('Authorization', 'Bearer valid-token')
+      .send({
+        school: 'UNSW',
+        program: 'Bachelor of Engineering (Hons)',
+        major: 'Software Engineering',
+        endMonth: 11,
+        endYear: 2025
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ success: true });
+
+    // Verify the education was updated with correct data
+    expect(educationUpdates[0]).toMatchObject({
+      data: {
+        school_id: 1,
+        program_id: 2,
+        major_id: 3,
+        end_month: 11,
+        end_year: 2025
+      },
+      col: 'id',
+      val: '123',
+      profileCol: 'profile_id',
+      profileVal: 'user-123'
+    });
+
+    // Verify lookups were called
+    expect(lookupCalls.schools).toContainEqual({ name: 'UNSW', returnId: 1 });
+    expect(lookupCalls.programs).toContainEqual({ name: 'Bachelor of Engineering (Hons)', returnId: 2 });
+    expect(lookupCalls.majors).toContainEqual({ name: 'Software Engineering', returnId: 3 });
+  });
+
+  it('401 NOT_AUTHENTICATED: no Authorization header', async () => {
+    const response = await request(app)
+      .patch('/api/profile/educations/edu_123')
+      .send({ school: 'UNSW' });
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ code: 'NOT_AUTHENTICATED' });
+  });
+
+  it('401 NOT_AUTHENTICATED: Authorization header is invalid', async () => {
+    mockJwtVerify.mockImplementation(() => {
+      throw new Error('Invalid token');
+    });
+
+    const response = await request(app)
+      .patch('/api/profile/educations/edu_123')
+      .set('Authorization', 'Bearer invalid-token')
+      .send({ school: 'UNSW' });
+
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ code: 'NOT_AUTHENTICATED' });
+  });
+
+  
+  it('400 VALIDATION_ERROR: end year is before start year', async () => {
+    mockJwtVerify.mockReturnValue({ sub: 'user-123' });
+    
+    const response = await request(app)
+    .patch('/api/profile/educations/edu_123')
+    .set('Authorization', 'Bearer valid-token')
+    .send({ 
+      endMonth: 2,
+      endYear: 2019  // Before start year 2020
+    });
+    
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ code: 'VALIDATION_ERROR' });
+  });
+  
+  it('400 VALIDATION_ERROR: end month is before start month in same year', async () => {
+    mockJwtVerify.mockReturnValue({ sub: 'user-123' });
+    
+    const response = await request(app)
+    .patch('/api/profile/educations/edu_123')
+    .set('Authorization', 'Bearer valid-token')
+    .send({ 
+      endMonth: 2, // Before start month 3
+      endYear: 2020 // Same as start year
+    });
+    
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ code: 'VALIDATION_ERROR' });
+  });
+  
+  it('404 NOT_FOUND: when education not found', async () => {
+    mockJwtVerify.mockReturnValue({ sub: 'user-123' });
+  
+    const response = await request(app)
+      .patch('/api/profile/educations/edu_456')
+      .set('Authorization', 'Bearer valid-token')
+      .send({ school: 'UNSW' });
+  
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ code: 'NOT_FOUND' });
+  });
+});


### PR DESCRIPTION
Features implemented:

- Updates an existing education record for an authorized user
- Deletes an existing education record for an authorized user

Files modified:

- educations.services.ts - Added updateProfileEducation + deleteProfileEducation function

- profile.routes.ts - Added PATCH /profile/educations/:id + DELETE  /profile/educations/:id routes

- profile.schemas.ts - Made UpdateEducationSchema 

- openapi.yaml - Added complete API documentation

Files added:

- profile-educations.patch.test.ts
- profile-educations.delete.test.ts

OpenAPI docs:
**UPDATE**:
<img width="2156" height="1234" alt="image" src="https://github.com/user-attachments/assets/91deb145-e0df-4b28-ae79-9b0dc7afd4c9" />
<img width="2202" height="1224" alt="image" src="https://github.com/user-attachments/assets/831f688b-671b-4889-82c4-e2b22865278e" />


GET **BEFORE** UPDATE
<img width="952" height="706" alt="image" src="https://github.com/user-attachments/assets/35e9b912-0ee6-4140-b74c-86788d9d7b18" />
GET **AFTER** UPDATE
<img width="754" height="361" alt="image" src="https://github.com/user-attachments/assets/b5017aa8-5cc5-44e8-97a6-c5f221490ad6" />

**DELETE**:
<img width="2267" height="1394" alt="image" src="https://github.com/user-attachments/assets/d71b3381-0c6e-4493-ae92-1d9019bfc4a0" />


All tests:
<img width="522" height="139" alt="image" src="https://github.com/user-attachments/assets/1ee18ccc-91cc-46c7-aafa-78bc52aab35e" />

Update education test:
<img width="1235" height="407" alt="image" src="https://github.com/user-attachments/assets/e6fbb87f-a99e-41a1-ae67-01a73dcf9142" />

Delete education test:
<img width="1096" height="364" alt="image" src="https://github.com/user-attachments/assets/af9f5f8f-2d3d-444d-a251-7116a88c8ee6" />

