### PR TITLE
W3 be search and filter jansen

### DIFF
--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -20,6 +20,8 @@ tags:
     description: Profile data, skills, media, and preferences
   - name: Handles
     description: Public profile handles (unique slugs)
+  - name: Search
+    description: Directory search and lookups (majors, companies, fields, cities)
 
 paths:
   /auth/register:
@@ -2116,7 +2118,107 @@ paths:
                 bad_format: { value: { code: VALIDATION_ERROR } }
         "500":
           $ref: "#/components/responses/InternalError"
-          
+
+  /directory/search:
+    get:
+      tags: ["Search"]
+      summary: Search member directory
+      description: |
+        Returns a paginated list of public profiles matching the given filters.
+        - **OR within** each list param (`major`, `companies`, `workFields`, `cities`, `citizenship`)
+        - **AND across** different params (e.g., `major` AND `cities`)
+        - `cities` must exactly match values from `/lookup/cities` (case-insensitive)
+        - `citizenship` allow-list: `Citizen`, `Permanent Resident`
+        - If `q` is absent and `sortBy=relevance`, treat as `name_asc`
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: q
+          schema: { type: string }
+          description: Case-insensitive partial match on full name
+          example: "jane"
+        - in: query
+          name: major
+          schema: { type: string }
+          description: Comma-separated list of **major names** (case-insensitive exact; matches profile.major or any education.major)
+          example: "Software Engineering,Mechanical Engineering"
+        - in: query
+          name: companies
+          schema: { type: string }
+          description: Comma-separated list of company names (case-insensitive exact; sourced from experiences)
+          example: "Google,Grab"
+        - in: query
+          name: workFields
+          schema: { type: string }
+          description: Comma-separated list of predefined field-of-work names (case-insensitive; sourced from experiences)
+          example: "Software Engineering,Data Science"
+        - in: query
+          name: cities
+          schema: { type: string }
+          description: Comma-separated list of domicile city names (case-insensitive **exact**; must come from `/lookup/cities`)
+          example: "Jakarta,Medan"
+        - in: query
+          name: citizenship
+          schema:
+            type: string
+            description: Comma-separated set from the allow-list
+            example: "Citizen,Permanent Resident"
+        - in: query
+          name: page
+          schema: { type: integer, minimum: 1, default: 1 }
+        - in: query
+          name: pageSize
+          schema: { type: integer, minimum: 1, maximum: 100, default: 20 }
+        - in: query
+          name: sortBy
+          schema:
+            type: string
+            enum: [relevance, name_asc, name_desc]
+            default: relevance
+          description: When `q` is absent, `relevance` behaves as `name_asc`.
+      responses:
+        "200":
+          description: Search results
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DirectorySearchResponse"
+              examples:
+                sample:
+                  value:
+                    results:
+                      - profileId: "usr_abc123"
+                        fullName: "Jane Doe"
+                        handle: "jane_doe"
+                        photoUrl: "https://cdn.app.com/profiles/usr_abc123/photo.jpg"
+                        headline: "Backend Engineer @ Acme | AI/ML"
+                        domicileCity: "Jakarta"
+                        domicileCountry: "ID"
+                        citizenshipStatus: "Citizen"
+                    pagination:
+                      total: 150
+                      page: 1
+                      pageSize: 20
+                      totalPages: 8
+        "400":
+          description: No filters provided or validation error
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorSimple" }
+              examples:
+                missing_filters:
+                  value: { code: VALIDATION_ERROR }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorSimple" }
+              examples:
+                no_auth: { value: { code: NOT_AUTHENTICATED } }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   /lookup/majors:
     get:
       tags: ["Search"]
@@ -3506,3 +3608,60 @@ components:
           type: string
           nullable: true
           maxLength: 2000
+    DirectorySearchResponse:
+      type: object
+      required: [results, pagination]
+      properties:
+        results:
+          type: array
+          items:
+            $ref: "#/components/schemas/DirectorySearchResult"
+        pagination:
+          $ref: "#/components/schemas/Pagination"
+
+    DirectorySearchResult:
+      type: object
+      required:
+        - profileId
+        - fullName
+      properties:
+        profileId:
+          type: string
+          description: Profile UUID
+          example: "2abc8f8a-a7cc-4fbe-9628-55bc8bd24579"
+        fullName:
+          type: string
+          example: "Jane Doe"
+        handle:
+          type: string
+          nullable: true
+          example: "jane_doe"
+        photoUrl:
+          type: string
+          nullable: true
+          example: "https://cdn.app.com/profiles/usr_abc123/photo.jpg"
+        headline:
+          type: string
+          nullable: true
+          example: "Backend Engineer @ Acme | AI/ML"
+        domicileCity:
+          type: string
+          nullable: true
+          example: "Jakarta"
+        domicileCountry:
+          type: string
+          nullable: true
+          example: "ID"
+        citizenshipStatus:
+          type: string
+          nullable: true
+          enum: ["Citizen", "Permanent Resident"]
+
+    Pagination:
+      type: object
+      required: [total, page, pageSize, totalPages]
+      properties:
+        total:      { type: integer, example: 150 }
+        page:       { type: integer, example: 1 }
+        pageSize:   { type: integer, example: 20 }
+        totalPages: { type: integer, example: 8 }

--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -1253,6 +1253,7 @@ paths:
                     headline: "Software Engineer"
                     domicileCity: "Sydney"
                     domicileCountry: "AU"
+                    citizenshipStatus: "Permanent Resident"
                     bio: "Passionate about building innovative software solutions."
                     socialLinks:
                       linkedin: "https://www.linkedin.com/in/janedoe"
@@ -1284,6 +1285,7 @@ paths:
         - `yearStart`, `yearGrad`: Must be between 2000-2100
         - `yearGrad`: Must be after `yearStart` if both provided
         - `domicileCountry`: Must be ISO country code (2 uppercase letters)
+        - `citizenshipStatus`: Must be either Citizen or Permanent Resident
         
         **Auth:** Bearer token required.
       security:
@@ -1308,6 +1310,7 @@ paths:
                   yearGrad: 2026
                   domicileCity: "Sydney"
                   domicileCountry: "AU"
+                  citizenshipStatus: "Citizen"
                   bio: "I ship boring, reliable services."
               partial_update:
                 summary: Partial update (only some fields)
@@ -2527,6 +2530,7 @@ paths:
                     headline: "Software Engineer"
                     domicileCity: "Sydney"
                     domicileCountry: "AU"
+                    citizenshipStatus: "Citizen"
                     bio: "Passionate about building innovative software solutions."
                     socialLinks:
                       linkedin: "https://www.linkedin.com/in/janedoe"

--- a/backend/src/routes/search.routes.ts
+++ b/backend/src/routes/search.routes.ts
@@ -5,127 +5,135 @@ import { listMajors, lookupCompanies, listWorkFields, searchDirectory } from "..
 const router = Router();
 
 router.get("/directory/search", async (req, res) => {
-  const accessToken = req.headers.authorization?.split(" ")[1];
-  if (!accessToken) return res.status(401).json({ code: "NOT_AUTHENTICATED" });
-  try {
-    jwt.verify(accessToken, process.env.JWT_SECRET!);
-  } catch {
-    return res.status(401).json({ code: "NOT_AUTHENTICATED" });
-  }
+	const accessToken = req.headers.authorization?.split(" ")[1];
+	if (!accessToken) return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+	try {
+			jwt.verify(accessToken, process.env.JWT_SECRET!);
+	} catch {
+			return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+	}
 
-  const q = String(req.query.q ?? "").trim();
-  const citiesParam = String(req.query.cities ?? "");
-  const citizenshipParam = String(req.query.citizenship ?? "");
-  const sortBy = String(req.query.sortBy ?? "relevance");
-  const page = Math.max(1, parseInt(String(req.query.page ?? "1"), 10) || 1);
-  const pageSizeRaw = Math.min(100, parseInt(String(req.query.pageSize ?? "20"), 10) || 20);
-  const pageSize = Math.max(1, pageSizeRaw);
+	const q = String(req.query.q ?? "").trim();
+	const majorsParam = String(req.query.major ?? "");
+	const citiesParam = String(req.query.cities ?? "");
+	const citizenshipParam = String(req.query.citizenship ?? "");
+	const sortBy = String(req.query.sortBy ?? "relevance");
+	const page = Math.max(1, parseInt(String(req.query.page ?? "1"), 10) || 1);
+	const pageSizeRaw = Math.min(100, parseInt(String(req.query.pageSize ?? "20"), 10) || 20);
+	const pageSize = Math.max(1, pageSizeRaw);
 
-  const splitList = (s: string) =>
-    s.split(",").map(x => x.trim()).filter(Boolean);
+	const splitList = (s: string) =>
+			s.split(",").map(x => x.trim()).filter(Boolean);
 
-  const cities = splitList(citiesParam);
-  const citizenshipRaw = splitList(citizenshipParam).map(x => x.toLowerCase());
+	const cities = splitList(citiesParam);
+	const citizenshipRaw = splitList(citizenshipParam).map(x => x.toLowerCase());
+	const majors = splitList(majorsParam);
 
-  // Allow-list for citizenship (case-insensitive → enum casing)
-  const toCitizenEnum = (v: string) =>
-    v === "citizen" ? "Citizen" :
-    v === "permanent resident" || v === "pr" ? "Permanent Resident" :
-    null;
-  const citizenship = Array.from(new Set(
-    citizenshipRaw.map(toCitizenEnum).filter((x): x is "Citizen" | "Permanent Resident" => !!x)
-  ));
+	// Allow-list for citizenship (case-insensitive → enum casing)
+	const toCitizenEnum = (v: string) =>
+			v === "citizen" ? "Citizen" :
+			v === "permanent resident" || v === "pr" ? "Permanent Resident" :
+			null;
+	const citizenship = Array.from(new Set(
+			citizenshipRaw.map(toCitizenEnum).filter((x): x is "Citizen" | "Permanent Resident" => !!x)
+	));
 
-  // Validation: need at least one of q|cities|citizenship|more
-  if (!q && cities.length === 0 && citizenship.length === 0) {
-    return res.status(400).json({ code: "VALIDATION_ERROR" });
-  }
+	// Validation: need at least one of q|cities|citizenship|more
+	if (
+			!q &&
+			majors.length === 0 &&
+			cities.length === 0 &&
+			citizenship.length === 0
+	) {
+	return res.status(400).json({ code: "VALIDATION_ERROR" });
+	}
 
-  try {
-    const { results, total } = await searchDirectory({
-      q,
-      cities,
-      citizenship,
-      sortBy,
-      page,
-      pageSize,
-    });
+	try {
+			const { results, total } = await searchDirectory({
+			q,
+			cities,
+			citizenship,
+			majors,
+			sortBy,
+			page,
+			pageSize,
+			});
 
-    return res.status(200).json({
-      results,
-      pagination: {
-        total,
-        page,
-        pageSize,
-        totalPages: Math.max(1, Math.ceil(total / pageSize)),
-      },
-    });
-  } catch (err) {
-    console.error("directory.search.error", err);
-    return res.status(500).json({ code: "INTERNAL" });
-  }
+			return res.status(200).json({
+			results,
+			pagination: {
+					total,
+					page,
+					pageSize,
+					totalPages: Math.max(1, Math.ceil(total / pageSize)),
+			},
+			});
+	} catch (err) {
+			console.error("directory.search.error", err);
+			return res.status(500).json({ code: "INTERNAL" });
+	}
 });
 
 router.get("/lookup/majors", async (req, res) => {
-    const accessToken = req.headers.authorization?.split(" ")[1];
-    if (!accessToken) {
-        return res.status(401).json({ code: "NOT_AUTHENTICATED" });
-    }
+	const accessToken = req.headers.authorization?.split(" ")[1];
+	if (!accessToken) {
+			return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+	}
 
-    try {
-        jwt.verify(accessToken, process.env.JWT_SECRET!);
-    } catch {
-        return res.status(401).json({ code: "NOT_AUTHENTICATED" });
-    }
+	try {
+			jwt.verify(accessToken, process.env.JWT_SECRET!);
+	} catch {
+			return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+	}
 
-    try {
-        const majors = await listMajors();
-        return res.status(200).json(majors);
-    } catch (err) {
-        console.error("listMajors.error", err);
-        return res.status(500).json({ code: "INTERNAL" });
-    }
+	try {
+			const majors = await listMajors();
+			return res.status(200).json(majors);
+	} catch (err) {
+			console.error("listMajors.error", err);
+			return res.status(500).json({ code: "INTERNAL" });
+	}
 });
 
 router.get("/lookup/companies", async (req, res) => {
-    const accessToken = req.headers.authorization?.split(" ")[1];
-    if (!accessToken) return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+	const accessToken = req.headers.authorization?.split(" ")[1];
+	if (!accessToken) return res.status(401).json({ code: "NOT_AUTHENTICATED" });
 
-    try {
-        jwt.verify(accessToken, process.env.JWT_SECRET!) as any;
-    } catch (error) {
-        return res.status(401).json({ code: "NOT_AUTHENTICATED" });
-    }
+	try {
+			jwt.verify(accessToken, process.env.JWT_SECRET!) as any;
+	} catch (error) {
+			return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+	}
 
-    const q = String(req.query.q || "");
-    try {
-        const companies = await lookupCompanies(q);
-        return res.status(200).json(companies);
-    } catch (err) {
-        console.error("lookup.companies.error", err);
-        return res.status(500).json({ code: "INTERNAL" });
-    }
+	const q = String(req.query.q || "");
+	try {
+			const companies = await lookupCompanies(q);
+			return res.status(200).json(companies);
+	} catch (err) {
+			console.error("lookup.companies.error", err);
+			return res.status(500).json({ code: "INTERNAL" });
+	}
 });
 
 router.get("/lookup/work-fields", async (req, res) => {
-    const accessToken = req.headers.authorization?.split(" ")[1];
-    if (!accessToken) {
-        return res.status(401).json({ code: "NOT_AUTHENTICATED" });
-    }
-    
-    try {
-        jwt.verify(accessToken, process.env.JWT_SECRET!);
-    } catch {
-        return res.status(401).json({ code: "NOT_AUTHENTICATED" });
-    }
-    
-    try {
-        const workFields = await listWorkFields();
-        return res.status(200).json(workFields);
-    } catch (err) {
-        console.error("listWorkFields.error", err);
-        return res.status(500).json({ code: "INTERNAL" });
-    }
+	const accessToken = req.headers.authorization?.split(" ")[1];
+	if (!accessToken) {
+			return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+	}
+	
+	try {
+			jwt.verify(accessToken, process.env.JWT_SECRET!);
+	} catch {
+			return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+	}
+	
+	try {
+			const workFields = await listWorkFields();
+			return res.status(200).json(workFields);
+	} catch (err) {
+			console.error("listWorkFields.error", err);
+			return res.status(500).json({ code: "INTERNAL" });
+	}
 });
 
 export default router;

--- a/backend/src/routes/search.routes.ts
+++ b/backend/src/routes/search.routes.ts
@@ -8,13 +8,15 @@ router.get("/directory/search", async (req, res) => {
 	const accessToken = req.headers.authorization?.split(" ")[1];
 	if (!accessToken) return res.status(401).json({ code: "NOT_AUTHENTICATED" });
 	try {
-			jwt.verify(accessToken, process.env.JWT_SECRET!);
+		jwt.verify(accessToken, process.env.JWT_SECRET!);
 	} catch {
-			return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+		return res.status(401).json({ code: "NOT_AUTHENTICATED" });
 	}
 
 	const q = String(req.query.q ?? "").trim();
 	const majorsParam = String(req.query.major ?? "");
+	const companiesParam = String(req.query.companies ?? "");
+	const workFieldsParam = String(req.query.workFields ?? "");
 	const citiesParam = String(req.query.cities ?? "");
 	const citizenshipParam = String(req.query.citizenship ?? "");
 	const sortBy = String(req.query.sortBy ?? "relevance");
@@ -23,75 +25,81 @@ router.get("/directory/search", async (req, res) => {
 	const pageSize = Math.max(1, pageSizeRaw);
 
 	const splitList = (s: string) =>
-			s.split(",").map(x => x.trim()).filter(Boolean);
+		s.split(",").map(x => x.trim()).filter(Boolean);
 
 	const cities = splitList(citiesParam);
 	const citizenshipRaw = splitList(citizenshipParam).map(x => x.toLowerCase());
 	const majors = splitList(majorsParam);
+	const companies = splitList(companiesParam);
+	const workFields = splitList(workFieldsParam);
 
 	// Allow-list for citizenship (case-insensitive → enum casing)
 	const toCitizenEnum = (v: string) =>
-			v === "citizen" ? "Citizen" :
-			v === "permanent resident" || v === "pr" ? "Permanent Resident" :
-			null;
+		v === "citizen" ? "Citizen" :
+		v === "permanent resident" || v === "pr" ? "Permanent Resident" :
+		null;
 	const citizenship = Array.from(new Set(
-			citizenshipRaw.map(toCitizenEnum).filter((x): x is "Citizen" | "Permanent Resident" => !!x)
+		citizenshipRaw.map(toCitizenEnum).filter((x): x is "Citizen" | "Permanent Resident" => !!x)
 	));
 
 	// Validation: need at least one of q|cities|citizenship|more
 	if (
-			!q &&
-			majors.length === 0 &&
-			cities.length === 0 &&
-			citizenship.length === 0
+		!q &&
+		majors.length === 0 &&
+		companies.length === 0 &&
+		workFields.length === 0 &&
+		cities.length === 0 &&
+		citizenship.length === 0
 	) {
-	return res.status(400).json({ code: "VALIDATION_ERROR" });
+		return res.status(400).json({ code: "VALIDATION_ERROR" });
 	}
 
 	try {
-			const { results, total } = await searchDirectory({
+		const { results, total } = await searchDirectory({
 			q,
 			cities,
 			citizenship,
 			majors,
+			companies,
+			workFields,
 			sortBy,
 			page,
 			pageSize,
-			});
+		});
 
-			return res.status(200).json({
-			results,
-			pagination: {
-					total,
-					page,
-					pageSize,
-					totalPages: Math.max(1, Math.ceil(total / pageSize)),
-			},
-			});
+		return res.status(200).json({
+		results,
+		pagination: {
+			total,
+			page,
+			pageSize,
+			totalPages: Math.max(1, Math.ceil(total / pageSize)),
+		},
+		});
 	} catch (err) {
-			console.error("directory.search.error", err);
-			return res.status(500).json({ code: "INTERNAL" });
+		console.error("directory.search.error", err);
+		return res.status(500).json({ code: "INTERNAL" });
 	}
 });
 
 router.get("/lookup/majors", async (req, res) => {
 	const accessToken = req.headers.authorization?.split(" ")[1];
 	if (!accessToken) {
-			return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+		return res.status(401).json({ code: "NOT_AUTHENTICATED" });
 	}
 
 	try {
-			jwt.verify(accessToken, process.env.JWT_SECRET!);
+		jwt.verify(accessToken, process.env.JWT_SECRET!);
 	} catch {
-			return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+		return res.status(401).json({ code: "NOT_AUTHENTICATED" });
 	}
 
 	try {
-			const majors = await listMajors();
-			return res.status(200).json(majors);
+		const majors = await listMajors();
+		return res.status(200).json(majors);
 	} catch (err) {
-			console.error("listMajors.error", err);
-			return res.status(500).json({ code: "INTERNAL" });
+		console.error("listMajors.error", err);
+		return res.status(500).json({ code: "INTERNAL" });
 	}
 });
 
@@ -100,39 +108,39 @@ router.get("/lookup/companies", async (req, res) => {
 	if (!accessToken) return res.status(401).json({ code: "NOT_AUTHENTICATED" });
 
 	try {
-			jwt.verify(accessToken, process.env.JWT_SECRET!) as any;
+		jwt.verify(accessToken, process.env.JWT_SECRET!) as any;
 	} catch (error) {
-			return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+		return res.status(401).json({ code: "NOT_AUTHENTICATED" });
 	}
 
 	const q = String(req.query.q || "");
 	try {
-			const companies = await lookupCompanies(q);
-			return res.status(200).json(companies);
+		const companies = await lookupCompanies(q);
+		return res.status(200).json(companies);
 	} catch (err) {
-			console.error("lookup.companies.error", err);
-			return res.status(500).json({ code: "INTERNAL" });
+		console.error("lookup.companies.error", err);
+		return res.status(500).json({ code: "INTERNAL" });
 	}
 });
 
 router.get("/lookup/work-fields", async (req, res) => {
 	const accessToken = req.headers.authorization?.split(" ")[1];
 	if (!accessToken) {
-			return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+		return res.status(401).json({ code: "NOT_AUTHENTICATED" });
 	}
 	
 	try {
-			jwt.verify(accessToken, process.env.JWT_SECRET!);
+		jwt.verify(accessToken, process.env.JWT_SECRET!);
 	} catch {
-			return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+		return res.status(401).json({ code: "NOT_AUTHENTICATED" });
 	}
 	
 	try {
-			const workFields = await listWorkFields();
-			return res.status(200).json(workFields);
+		const workFields = await listWorkFields();
+		return res.status(200).json(workFields);
 	} catch (err) {
-			console.error("listWorkFields.error", err);
-			return res.status(500).json({ code: "INTERNAL" });
+		console.error("listWorkFields.error", err);
+		return res.status(500).json({ code: "INTERNAL" });
 	}
 });
 

--- a/backend/src/routes/search.routes.ts
+++ b/backend/src/routes/search.routes.ts
@@ -1,8 +1,70 @@
 import { Router } from "express";
 import jwt from "jsonwebtoken";
-import { listMajors, lookupCompanies, listWorkFields } from "../services/search.service";
+import { listMajors, lookupCompanies, listWorkFields, searchDirectory } from "../services/search.service";
 
 const router = Router();
+
+router.get("/directory/search", async (req, res) => {
+  const accessToken = req.headers.authorization?.split(" ")[1];
+  if (!accessToken) return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+  try {
+    jwt.verify(accessToken, process.env.JWT_SECRET!);
+  } catch {
+    return res.status(401).json({ code: "NOT_AUTHENTICATED" });
+  }
+
+  const q = String(req.query.q ?? "").trim();
+  const citiesParam = String(req.query.cities ?? "");
+  const citizenshipParam = String(req.query.citizenship ?? "");
+  const sortBy = String(req.query.sortBy ?? "relevance");
+  const page = Math.max(1, parseInt(String(req.query.page ?? "1"), 10) || 1);
+  const pageSizeRaw = Math.min(100, parseInt(String(req.query.pageSize ?? "20"), 10) || 20);
+  const pageSize = Math.max(1, pageSizeRaw);
+
+  const splitList = (s: string) =>
+    s.split(",").map(x => x.trim()).filter(Boolean);
+
+  const cities = splitList(citiesParam);
+  const citizenshipRaw = splitList(citizenshipParam).map(x => x.toLowerCase());
+
+  // Allow-list for citizenship (case-insensitive → enum casing)
+  const toCitizenEnum = (v: string) =>
+    v === "citizen" ? "Citizen" :
+    v === "permanent resident" || v === "pr" ? "Permanent Resident" :
+    null;
+  const citizenship = Array.from(new Set(
+    citizenshipRaw.map(toCitizenEnum).filter((x): x is "Citizen" | "Permanent Resident" => !!x)
+  ));
+
+  // Validation: need at least one of q|cities|citizenship|more
+  if (!q && cities.length === 0 && citizenship.length === 0) {
+    return res.status(400).json({ code: "VALIDATION_ERROR" });
+  }
+
+  try {
+    const { results, total } = await searchDirectory({
+      q,
+      cities,
+      citizenship,
+      sortBy,
+      page,
+      pageSize,
+    });
+
+    return res.status(200).json({
+      results,
+      pagination: {
+        total,
+        page,
+        pageSize,
+        totalPages: Math.max(1, Math.ceil(total / pageSize)),
+      },
+    });
+  } catch (err) {
+    console.error("directory.search.error", err);
+    return res.status(500).json({ code: "INTERNAL" });
+  }
+});
 
 router.get("/lookup/majors", async (req, res) => {
     const accessToken = req.headers.authorization?.split(" ")[1];

--- a/backend/src/services/profile.service.ts
+++ b/backend/src/services/profile.service.ts
@@ -32,6 +32,7 @@ type ProfileRow = {
   headline: string | null;
   domicile_city: string | null;
   domicile_country: string | null;
+  citizenship_status: 'Citizen' | 'Permanent Resident',
   bio: string | null;
   social_links: any;
   created_at: string;
@@ -171,6 +172,7 @@ export async function getProfileDetails(profileId: string): Promise<ProfileObjec
       social_links,
       created_at,
       updated_at,
+      citizenship_status,
       programs:programs!fk_profiles_program ( name ),
       majors:majors!fk_profiles_major     ( name )
 		`)
@@ -198,6 +200,7 @@ export async function getProfileDetails(profileId: string): Promise<ProfileObjec
     headline: data.headline,
     domicileCity: data.domicile_city,
     domicileCountry: data.domicile_country,
+    citizenshipStatus: data.citizenship_status,
     bio: data.bio,
     socialLinks: data.social_links,
     createdAt: data.created_at,
@@ -343,6 +346,7 @@ export async function updateProfile(profileId: string, updates: UpdateProfileInp
   if (updates.yearGrad !== undefined) updateData.year_grad = updates.yearGrad;
   if (updates.domicileCity !== undefined) updateData.domicile_city = updates.domicileCity;
   if (updates.domicileCountry !== undefined) updateData.domicile_country = updates.domicileCountry;
+  if (updates.citizenshipStatus !== undefined) updateData.citizenship_status = updates.citizenshipStatus;
   if (updates.bio !== undefined) updateData.bio = updates.bio;
 
   if (updates.program !== undefined) {
@@ -404,6 +408,7 @@ export async function getPublicProfileByHandle(handle: string): Promise<Omit<Pro
       headline,
       domicile_city,
       domicile_country,
+      citizenship_status,
       bio,
       social_links,
       created_at,
@@ -441,6 +446,7 @@ export async function getPublicProfileByHandle(handle: string): Promise<Omit<Pro
     headline: data.headline,
     domicileCity: data.domicile_city,
     domicileCountry: data.domicile_country,
+    citizenshipStatus: data.citizenship_status,
     bio: data.bio,
     socialLinks: data.social_links,
     createdAt: data.created_at,

--- a/backend/src/services/search.service.ts
+++ b/backend/src/services/search.service.ts
@@ -1,5 +1,111 @@
 import { supabase } from "../lib/supabase";
 
+type SearchParams = {
+  q: string;
+  cities: string[];
+  citizenship: Array<"Citizen" | "Permanent Resident">;
+  sortBy: "relevance" | "name_asc" | "name_desc" | string;
+  page: number;
+  pageSize: number;
+};
+
+type ProfilePublicRow = {
+  id: string;
+  full_name: string;
+  handle: string | null;
+  photo_url: string | null;
+  headline: string | null;
+  domicile_city: string | null;
+  domicile_country: string | null;
+  citizenship_status: "Citizen" | "Permanent Resident" | null;
+};
+
+export async function searchDirectory(params: SearchParams) {
+  const { q, cities, citizenship, sortBy, page, pageSize } = params;
+
+  // pagination → PostgREST range is 0-indexed, inclusive
+  const from = (page - 1) * pageSize;
+  const to = from + pageSize - 1;
+
+  // Base select: only the “public view” fields we expose
+  let query = supabase
+    .from("profiles")
+    .select(
+      [
+        "id",
+        "full_name",
+        "handle",
+        "photo_url",
+        "headline",
+        "domicile_city",
+        "domicile_country",
+        "citizenship_status",
+      ].join(","),
+      { count: "exact" }
+    )
+    // directory visibility guard (adjust if your policy allows "members")
+    .eq("visibility", "public"); // keep it strict per spec’s “public view”
+
+  // q: case-insensitive partial match on full_name
+  if (q) {
+    // ilike with wildcards → partial, case-insensitive
+    query = query.ilike("full_name", `%${q}%`);
+  }
+
+  // cities: OR within list; case-insensitive equality
+  if (cities.length > 0) {
+    const cityClauses = cities.map((c) => `domicile_city.ilike.${escapeDot(c)}`).join(",");
+    query = query.or(cityClauses);
+
+    // enforce Indonesian profiles only
+    query = query.eq("domicile_country", "ID").eq("is_indonesian", true);
+  }
+
+  // citizenship: exact match on enum values; OR within list
+  if (citizenship.length > 0) {
+    query = query.in("citizenship_status", citizenship);
+  }
+
+  // Sorting
+  const hasQ = Boolean(q);
+  const sort = ((): { column: string; ascending: boolean } => {
+    if (sortBy === "name_asc" || (!hasQ && sortBy === "relevance"))
+      return { column: "full_name", ascending: true };
+    if (sortBy === "name_desc") return { column: "full_name", ascending: false };
+    // "relevance" w/ q present — simple fallback: name_asc (you can upgrade to pg_trgm later)
+    return { column: "full_name", ascending: true };
+  })();
+  query = query.order(sort.column, { ascending: sort.ascending });
+
+  // Range + execute
+  const { data, error, count } = await query
+  .returns<ProfilePublicRow[]>()
+  .range(from, to);
+
+  if (error) throw error;
+
+  // Shape to API payload
+  const results = (data ?? []).map((row) => ({
+    profileId: row.id,
+    fullName: row.full_name,
+    handle: row.handle,
+    photoUrl: row.photo_url,
+    headline: row.headline,
+    domicileCity: row.domicile_city,
+    domicileCountry: row.domicile_country,
+    citizenshipStatus: row.citizenship_status,
+  }));
+
+  return { results, total: count ?? 0 };
+}
+
+// helper to escape dots & commas inside OR clause tokens
+function escapeDot(value: string) {
+  // PostgREST OR syntax uses '.' as operator separator; escape with URL encoding
+  // We also replace commas which separate conditions.
+  return encodeURIComponent(value);
+}
+
 export async function listMajors(): Promise<{ id: number; name: string }[]> {
     const { data, error } = await supabase
         .from("majors")

--- a/backend/src/types/Profile.ts
+++ b/backend/src/types/Profile.ts
@@ -14,6 +14,7 @@ export interface ProfileObject {
   headline: string | null;
   domicileCity: string | null;
   domicileCountry: string | null;
+  citizenshipStatus: 'Citizen' | 'Permanent Resident',
   bio: string | null;
   socialLinks: any;
   createdAt: string;

--- a/backend/src/validation/profile.schemas.ts
+++ b/backend/src/validation/profile.schemas.ts
@@ -16,6 +16,7 @@ export const UpdateProfileSchema = z.object({
   yearGrad: z.number().int().min(2000).max(2100).nullable().optional(),
   domicileCity: z.string().nullable().optional(),
   domicileCountry: z.string().regex(/^[A-Z]{2}$/).nullable().optional(),
+  citizenshipStatus: z.enum(['Permanent Resident', 'Citizen']).optional(),
   bio: z.string().nullable().optional(),
 }).refine((data) => {
   // Validate that yearGrad is after yearStart if both are provided

--- a/backend/tests/directory.search.test.ts
+++ b/backend/tests/directory.search.test.ts
@@ -1,0 +1,420 @@
+import request from "supertest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+let app: ReturnType<Awaited<typeof import("../src/app")>["createApp"]>;
+const mockJwtVerify = vi.fn();
+
+// ---------- In-memory fixtures the mock will use ----------
+let mockProfilesRows: Array<any> = [];
+let mockMajorsRows: Array<{ id: number; name: string }> = [];
+let mockEducationsRows: Array<{ profile_id: string; major_id: number }> = [];
+let mockCompaniesRows: Array<{ id: number; name: string }> = [];
+let mockFieldsRows: Array<{ id: number; name: string }> = [];
+let mockExperiencesRows: Array<{
+  profile_id: string;
+  company_id: number | null;
+  field_of_work_id: number | null;
+}> = [];
+
+// ---------- JWT mock ----------
+vi.mock("jsonwebtoken", () => ({
+  default: { verify: mockJwtVerify },
+  verify: mockJwtVerify,
+}));
+
+// ---------- Supabase mock ----------
+vi.doMock("../src/lib/supabase", () => {
+  const makeBuilder = (table: string) => {
+    // --- state for this query chain ---
+    let idFilter: string[] | null = null;               // profiles.id IN (...)
+    let nameIlike: string | null = null;                // profiles.full_name ILIKE '%...%'
+    let cityIlikeList: string[] | null = null;          // from or(domicile_city.ilike.A, ...)
+    let eqMap: Record<string, any> = {};                // eq filters (domicile_country, is_indonesian, visibility)
+    let citizenshipIn: string[] | null = null;          // citizenship_status IN (...)
+
+    const builder: any = {
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      returns: vi.fn().mockReturnThis(),
+
+      ilike: vi.fn().mockImplementation((col: string, pattern: string) => {
+        if (table === "profiles" && col === "full_name") {
+          nameIlike = pattern; // "%Jane%"
+        }
+        return builder;
+      }),
+
+      or: vi.fn().mockImplementation((logic: string) => {
+        // Expect: "domicile_city.ilike.Jakarta,domicile_city.ilike.Bandung"
+        if (table === "profiles" && logic) {
+          const parts = logic.split(",");
+          const cities: string[] = [];
+          for (const token of parts) {
+            const seg = token.trim();
+            const prefix = "domicile_city.ilike.";
+            if (seg.startsWith(prefix)) {
+              const raw = seg.slice(prefix.length);
+              cities.push(decodeURIComponent(raw));
+            }
+          }
+          if (cities.length > 0) cityIlikeList = cities;
+        }
+        return builder;
+      }),
+
+      eq: vi.fn().mockImplementation((col: string, val: any) => {
+        // Save for later filtering in range()
+        eqMap[col] = val;
+        return builder;
+      }),
+
+      in: vi.fn().mockImplementation((col: string, values: any[]) => {
+        // Main directory query uses: profiles.in('id', ids)
+        if (table === "profiles" && col === "id") {
+          idFilter = Array.isArray(values) ? values : [];
+          return builder;
+        }
+
+        // When building IDs from profile.major → profiles.in('major_id', ids)
+        if (table === "profiles" && col === "major_id") {
+          const rows = mockProfilesRows
+            .filter(r => values.includes(r.major_id))
+            .map(r => ({ id: r.id }));
+          return Promise.resolve({ data: rows, error: null });
+        }
+
+        // majors.in('name', [...])
+        if (table === "majors" && col === "name") {
+          const data = mockMajorsRows.filter(m => values.includes(m.name));
+          return Promise.resolve({ data, error: null });
+        }
+
+        // educations.in('major_id', [...]) → profile_id list
+        if (table === "educations" && col === "major_id") {
+          const data = mockEducationsRows
+            .filter(e => values.includes(e.major_id))
+            .map(e => ({ profile_id: e.profile_id }));
+          return Promise.resolve({ data, error: null });
+        }
+
+        // companies.in('name', [...]) for the prefetch step
+        if (table === "companies" && col === "name") {
+          const data = mockCompaniesRows.filter(c => values.includes(c.name));
+          return Promise.resolve({ data, error: null });
+        }
+
+        // fields_of_work.in('name', [...]) for the prefetch step
+        if (table === "fields_of_work" && col === "name") {
+          const data = mockFieldsRows.filter(f => values.includes(f.name));
+          return Promise.resolve({ data, error: null });
+        }
+
+        // experiences.in('company_id' | 'field_of_work_id', [...]) → profile_id list
+        if (table === "experiences" && (col === "company_id" || col === "field_of_work_id")) {
+          const data = mockExperiencesRows
+            .filter(x => values.includes(x[col] as number))
+            .map(x => ({ profile_id: x.profile_id }));
+          return Promise.resolve({ data, error: null });
+        }
+
+        // profiles.in('citizenship_status', [...]) — record for later filtering
+        if (table === "profiles" && col === "citizenship_status") {
+          citizenshipIn = Array.isArray(values) ? values : [];
+          return builder;
+        }
+
+        return builder;
+      }),
+
+      range: vi.fn().mockImplementation((_from: number, _to: number) => {
+        // Apply all accumulated filters to mockProfilesRows
+        let data = mockProfilesRows.slice();
+
+        // visibility=public (service sets this)
+        if (eqMap["visibility"]) {
+          data = data.filter(r => r.visibility === eqMap["visibility"]);
+        }
+
+        // name ILIKE
+        if (nameIlike) {
+          const needle = nameIlike.replace(/^%|%$/g, "").toLowerCase();
+          data = data.filter(r => (r.full_name ?? "").toLowerCase().includes(needle));
+        }
+
+        // cities OR ILIKE list
+        if (cityIlikeList && cityIlikeList.length > 0) {
+          const lc = cityIlikeList.map(c => c.toLowerCase());
+          data = data.filter(r => r.domicile_city && lc.some(c => r.domicile_city!.toLowerCase().includes(c)));
+        }
+
+        // eq filters (domicile_country, is_indonesian, etc.)
+        Object.entries(eqMap).forEach(([k, v]) => {
+          if (k === "visibility") return; // already applied
+          data = data.filter(r => r[k] === v);
+        });
+
+        // citizenship_status IN (...)
+        if (citizenshipIn && citizenshipIn.length > 0) {
+          const set = new Set(citizenshipIn);
+          data = data.filter(r => set.has(r.citizenship_status));
+        }
+
+        // id IN (...)
+        if (idFilter) {
+          const set = new Set(idFilter);
+          data = data.filter(r => set.has(r.id));
+        }
+
+        // simple count + full slice (we don't need real pagination slicing for these tests)
+        return Promise.resolve({ data, error: null, count: data.length });
+      }),
+    };
+
+    return builder;
+  };
+
+  return {
+    supabase: {
+      from: (table: string) => makeBuilder(table),
+    },
+  };
+});
+
+// ---------- helper ----------
+async function buildApp() {
+  const mod = await import("../src/app");
+  return mod.createApp();
+}
+
+beforeEach(async () => {
+  await vi.resetModules();
+
+  // reset mocks
+  mockJwtVerify.mockImplementation(() => ({ sub: "user-id" }));
+
+  // default datasets are empty; each test will fill what it needs
+  mockProfilesRows = [];
+  mockMajorsRows = [];
+  mockEducationsRows = [];
+  mockCompaniesRows = [];
+  mockFieldsRows = [];
+  mockExperiencesRows = [];
+
+  app = await buildApp();
+});
+
+const route = "/api/directory/search";
+
+/**
+ * NOTE about expectations:
+ * The search endpoint returns **DirectorySearchResult** (profile core),
+ * not raw majors/companies/fields. So we assert on the presence of
+ * the expected profile(s) rather than checking "major/company" fields.
+ */
+
+describe("GET /api/directory/search", () => {
+  it("SUCCESS (200): Filter by name query", async () => {
+    mockProfilesRows = [
+      {
+        id: "p1",
+        full_name: "Jane Doe",
+        handle: null,
+        photo_url: null,
+        headline: null,
+        domicile_city: "Jakarta",
+        domicile_country: "ID",
+        citizenship_status: "Citizen",
+        visibility: "public",
+      },
+      {
+        id: "p2",
+        full_name: "John Smith",
+        handle: null,
+        photo_url: null,
+        headline: null,
+        domicile_city: "Bandung",
+        domicile_country: "ID",
+        citizenship_status: "Citizen",
+        visibility: "public",
+      },
+    ];
+
+    const res = await request(app)
+      .get(route)
+      .query({ q: "Jane" })
+      .set("Authorization", "Bearer validtoken");
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toEqual([
+      expect.objectContaining({ fullName: "Jane Doe" }),
+    ]);
+  });
+
+  it("SUCCESS (200): Filter by major (profile.major OR education.major)", async () => {
+    // majors: SE -> id 1, ME -> id 2
+    mockMajorsRows = [
+      { id: 1, name: "Software Engineering" },
+      { id: 2, name: "Mechanical Engineering" },
+    ];
+
+    // Profiles
+    mockProfilesRows = [
+      {
+        id: "pa", full_name: "Alice", handle: null, photo_url: null, headline: null,
+        domicile_city: "Jakarta", domicile_country: "ID", citizenship_status: "Citizen", visibility: "public",
+        major_id: 1,
+      },
+      {
+        id: "pb", full_name: "Bob", handle: null, photo_url: null, headline: null,
+        domicile_city: "Jakarta", domicile_country: "ID", citizenship_status: "Citizen", visibility: "public",
+        major_id: 99,
+      },
+    ];
+
+    mockEducationsRows = [
+      { profile_id: "pb", major_id: 1 },
+    ];
+
+    const res = await request(app)
+      .get(route)
+      .query({ major: "Software Engineering" })
+      .set("Authorization", "Bearer validtoken");
+
+    expect(res.status).toBe(200);
+    const ids = res.body.results.map((r: any) => r.profileId);
+    expect(new Set(ids)).toEqual(new Set(["pa", "pb"]));
+  });
+
+  it("SUCCESS (200): Filter by companies (via experiences)", async () => {
+    mockCompaniesRows = [
+      { id: 10, name: "Google" },
+      { id: 20, name: "Grab" },
+    ];
+    mockProfilesRows = [
+      { id: "p1", full_name: "Nadia", handle: null, photo_url: null, headline: null, domicile_city: "Jakarta", domicile_country: "ID", citizenship_status: "Citizen", visibility: "public" },
+      { id: "p2", full_name: "Rizky", handle: null, photo_url: null, headline: null, domicile_city: "Jakarta", domicile_country: "ID", citizenship_status: "Citizen", visibility: "public" },
+    ];
+    mockExperiencesRows = [
+      { profile_id: "p1", company_id: 10, field_of_work_id: null }, // Google
+      { profile_id: "p2", company_id: 20, field_of_work_id: null }, // Grab
+    ];
+
+    const res = await request(app)
+      .get(route)
+      .query({ companies: "Google" })
+      .set("Authorization", "Bearer validtoken");
+
+    expect(res.status).toBe(200);
+    const names = res.body.results.map((r: any) => r.fullName);
+    expect(names).toContain("Nadia");
+    expect(names).not.toContain("Rizky");
+  });
+
+  it("SUCCESS (200): Filter by workFields (via experiences)", async () => {
+    mockFieldsRows = [
+      { id: 1, name: "Software Engineering" },
+      { id: 2, name: "Data Science" },
+    ];
+    mockProfilesRows = [
+      { id: "p1", full_name: "Intan", handle: null, photo_url: null, headline: null, domicile_city: "Jakarta", domicile_country: "ID", citizenship_status: "Citizen", visibility: "public" },
+      { id: "p2", full_name: "Yoga", handle: null, photo_url: null, headline: null, domicile_city: "Jakarta", domicile_country: "ID", citizenship_status: "Citizen", visibility: "public" },
+    ];
+    mockExperiencesRows = [
+      { profile_id: "p1", company_id: null, field_of_work_id: 2 }, // Data Science
+      { profile_id: "p2", company_id: null, field_of_work_id: 1 }, // Software Eng
+    ];
+
+    const res = await request(app)
+      .get(route)
+      .query({ workFields: "Data Science" })
+      .set("Authorization", "Bearer validtoken");
+
+    expect(res.status).toBe(200);
+    const names = res.body.results.map((r: any) => r.fullName);
+    expect(names).toContain("Intan");
+    expect(names).not.toContain("Yoga");
+  });
+
+  it("SUCCESS (200): Filter by cities (Indonesian only)", async () => {
+    mockProfilesRows = [
+      { id: "p1", full_name: "Dina", handle: null, photo_url: null, headline: null, domicile_city: "Jakarta", domicile_country: "ID", citizenship_status: "Citizen", visibility: "public", is_indonesian: true },
+      { id: "p2", full_name: "Maya", handle: null, photo_url: null, headline: null, domicile_city: "Sydney",  domicile_country: "AU", citizenship_status: "Citizen", visibility: "public", is_indonesian: true },
+    ];
+
+    const res = await request(app)
+      .get(route)
+      .query({ cities: "Jakarta" })
+      .set("Authorization", "Bearer validtoken");
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toEqual([
+      expect.objectContaining({ fullName: "Dina", domicileCity: "Jakarta" }),
+    ]);
+  });
+
+  it("SUCCESS (200): Filter by citizenship", async () => {
+    mockProfilesRows = [
+      { id: "p1", full_name: "Evan", handle: null, photo_url: null, headline: null, domicile_city: "Jakarta", domicile_country: "ID", citizenship_status: "Citizen", visibility: "public" },
+      { id: "p2", full_name: "Lia",  handle: null, photo_url: null, headline: null, domicile_city: "Jakarta", domicile_country: "ID", citizenship_status: "Permanent Resident", visibility: "public" },
+    ];
+
+    const res = await request(app)
+      .get(route)
+      .query({ citizenship: "Citizen" })
+      .set("Authorization", "Bearer validtoken");
+
+    expect(res.status).toBe(200);
+    const names = res.body.results.map((r: any) => r.fullName);
+    expect(names).toContain("Evan");
+    expect(names).not.toContain("Lia");
+  });
+
+  it("SUCCESS (200): Combination of filters (major + cities)", async () => {
+    mockMajorsRows = [{ id: 1, name: "Software Engineering" }];
+    mockProfilesRows = [
+      { id: "p1", full_name: "Fiona", handle: null, photo_url: null, headline: null, domicile_city: "Jakarta", domicile_country: "ID", citizenship_status: "Citizen", visibility: "public", major_id: 1, is_indonesian: true },
+      { id: "p2", full_name: "Gani",  handle: null, photo_url: null, headline: null, domicile_city: "Medan",   domicile_country: "ID", citizenship_status: "Citizen", visibility: "public", major_id: 1, is_indonesian: true },
+      { id: "p3", full_name: "Hadi",  handle: null, photo_url: null, headline: null, domicile_city: "Jakarta", domicile_country: "ID", citizenship_status: "Citizen", visibility: "public", major_id: 999, is_indonesian: true },
+    ];
+
+    const res = await request(app)
+      .get(route)
+      .query({ major: "Software Engineering", cities: "Jakarta" })
+      .set("Authorization", "Bearer validtoken");
+
+    expect(res.status).toBe(200);
+    const names = res.body.results.map((r: any) => r.fullName);
+    expect(names).toContain("Fiona");
+    expect(names).not.toContain("Gani");
+    expect(names).not.toContain("Hadi");
+  });
+
+  // ---- Error cases ----
+  it("ERROR (400): No filters provided", async () => {
+    const res = await request(app)
+      .get(route)
+      .set("Authorization", "Bearer validtoken");
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ code: "VALIDATION_ERROR" });
+  });
+
+  it("ERROR (401): No token", async () => {
+    const res = await request(app).get(route);
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ code: "NOT_AUTHENTICATED" });
+  });
+
+  it("ERROR (401): Invalid token", async () => {
+    mockJwtVerify.mockImplementationOnce(() => {
+      throw new Error("Invalid token");
+    });
+
+    const res = await request(app)
+      .get(route)
+      .set("Authorization", "Bearer badtoken");
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ code: "NOT_AUTHENTICATED" });
+  });
+});

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    sequence: { concurrent: false },
+    testTimeout:10_000,
+    hookTimeout: 100_000,
+    teardownTimeout: 15_000,
+  },
+});

--- a/supabase/migrations/202509010001_extensions_enums.sql
+++ b/supabase/migrations/202509010001_extensions_enums.sql
@@ -28,6 +28,10 @@ do $$ begin
   create type location_type as enum ('on_site','remote','hybrid');
 exception when duplicate_object then null; end $$;
 
+do $$ begin
+  create type citizenship_type as enum ('Permanent Resident', 'Citizen');
+exception when duplicate_object then null; end $$;
+
 create or replace function update_updated_at_column()
 returns trigger as $$
 begin

--- a/supabase/migrations/202509010002_profiles.sql
+++ b/supabase/migrations/202509010002_profiles.sql
@@ -16,6 +16,7 @@ create table if not exists profiles (
   headline varchar,
   domicile_city varchar,
   domicile_country char(2),
+  citizenship_status citizenship_type,
   bio text,
   social_links jsonb,
   visibility text not null default 'public',


### PR DESCRIPTION
## PR: User Story 3.1 – Search and Filter Directory

### Summary
This PR implements the **directory search and filtering** functionality (User Story 3.1).  
Users can now search and filter directory profiles based on multiple fields, ensuring a more flexible and powerful discovery experience.

### Changes
- **Profile Search & Filters**
  - Added **basic search** with `domicile_city` and `citizenship_status` filters.
  - Extended **profile GET** and **handle GET** to include `citizenship_status`.
  - Implemented **major filtering** based on both `user_profile_core` and `user_education`.
  - Added filtering by **companies** (via experiences).
  - Added filtering by **field of works** (via experiences).

- **API & Schema Updates**
  - Updated `openapi.yaml` to include new filter options.
  - Added 2 new files + tests for directory search.
  - Increased hook timeouts to stabilize test execution.

- **Repo Maintenance**
  - Merged latest changes from `main` and resolved conflicts.

### Testing
- ✅ Unit tests added for each new filter type.
- ✅ Verified searches with different filter combinations.
- ✅ Ensured backward compatibility for existing `/api/directory/search`.

<img width="939" height="910" alt="image" src="https://github.com/user-attachments/assets/547360ad-394b-441e-abe8-9b3c9299085e" />
<img width="892" height="454" alt="image" src="https://github.com/user-attachments/assets/2f5ed2c4-45a7-4b0b-967e-e20af1d712b5" />

---

Closes #72
