### PR TITLE
Implementing Accepting Connect Request Between 2 Users

### DIFF
--- a/backend/openapi/openapi.yaml
+++ b/backend/openapi/openapi.yaml
@@ -3015,14 +3015,14 @@ paths:
                           profileId: "user_def456"
                           fullName: "John Doe"
                           handle: "johndoe"
-                          avatar_url: "https://example.com/avatar1.jpg"
+                          photo_url: "https://example.com/avatar1.jpg"
                         created_at: "2024-01-15T10:00:00Z"
                       - id: "req_ghi789"
                         fromUser:
                           profileId: "user_jkl012"
                           fullName: "Jane Smith"
                           handle: "janesmith"
-                          avatar_url: "https://example.com/avatar2.jpg"
+                          photo_url: "https://example.com/avatar2.jpg"
                         created_at: "2024-01-14T09:00:00Z"
                     pagination:
                       total: 25
@@ -3038,7 +3038,7 @@ paths:
                           profileId: "user_pqr678"
                           fullName: "Alice Johnson"
                           handle: "alicejohnson"
-                          avatar_url: "https://example.com/avatar3.jpg"
+                          photo_url: "https://example.com/avatar3.jpg"
                         created_at: "2024-01-13T14:30:00Z"
                     pagination:
                       total: 5
@@ -3170,11 +3170,62 @@ paths:
         "500":
           $ref: "#/components/responses/InternalError"
 
+  /connections/requests/{id}/accept:
+    post:
+      tags: ["Connections"]
+      summary: Accept a pending connection request
+      description: |
+        Accept a **pending** connection request. Only the **receiver** of the request can accept.
+        Idempotent with respect to the `connections` row (unique pair).
+      operationId: acceptConnectionRequest
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string, format: uuid }
+          description: UUID of the connection request
+      responses:
+        "200":
+          description: Request accepted; users are now connected
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuccessOnly"
+              examples:
+                ok: { value: { success: true } }
+        "401":
+          description: Not authenticated
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorSimple" }
+              examples:
+                no_auth: { value: { code: NOT_AUTHENTICATED } }
+        "404":
+          description: Request not found OR not addressed to caller
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorSimple" }
+              examples:
+                not_found: { value: { code: NOT_FOUND } }
+        "409":
+          description: Request not in a valid state to accept (e.g., not pending)
+          content:
+            application/json:
+              schema: { $ref: "#/components/schemas/ErrorSimple" }
+              examples:
+                invalid_state: { value: { code: INVALID_STATE } }
+        "500":
+          $ref: "#/components/responses/InternalError"
+
   /connections/requests/{id}/cancel:
     post:
       tags: ["Connections"]
       summary: Cancel a pending connection request
       description: Withdraw a pending request.
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: id
@@ -3317,6 +3368,7 @@ paths:
           content:
             application/json:
               schema:
+                $ref: '#/components/schemas/RelationshipStatus'
                 type: object
                 required:
                   [connected, pendingOutgoing, pendingIncoming, blockedByMe, blockedMe, canSendRequest]
@@ -4285,6 +4337,7 @@ components:
           type: string
           description: Unique identifier for the connection request
           example: "req_abc123"
+        message: { type: string, nullable: true, example: "hey!" }
         fromUser:
           $ref: '#/components/schemas/UserProfile'
         created_at:
@@ -4305,6 +4358,7 @@ components:
           type: string
           description: Unique identifier for the connection request
           example: "req_abc123"
+        message: { type: string, nullable: true, example: null }
         toUser:
           $ref: '#/components/schemas/UserProfile'
         created_at:
@@ -4363,7 +4417,7 @@ components:
           type: string
           description: User's unique handle/username
           example: "johndoe"
-        avatar_url:
+        photo_url:
           type: string
           format: uri
           nullable: true
@@ -4373,4 +4427,14 @@ components:
         - profileId
         - fullName
         - handle
-        - avatar_url
+        - photo_url
+    RelationshipStatus:
+      type: object
+      required: [connected, pendingOutgoing, pendingIncoming, blockedByMe, blockedMe, canSendRequest]
+      properties:
+        connected:       { type: boolean }
+        pendingOutgoing: { type: boolean }
+        pendingIncoming: { type: boolean }
+        blockedByMe:     { type: boolean }
+        blockedMe:       { type: boolean }
+        canSendRequest:  { type: boolean }

--- a/backend/tests/connections.accept-request.test.ts
+++ b/backend/tests/connections.accept-request.test.ts
@@ -1,0 +1,177 @@
+// tests/connections.accept-request.test.ts
+import request from "supertest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+/** -------- JWT mock -------- */
+const mockJwtVerify = vi.fn();
+vi.mock("jsonwebtoken", () => ({
+  default: { verify: mockJwtVerify },
+  verify: mockJwtVerify,
+}));
+
+/** -------- Supabase mock (generic no-op) -------- */
+const noopPromise = Promise.resolve({ data: null, error: null });
+const qb = {
+  select: vi.fn(() => qb),
+  insert: vi.fn(() => qb),
+  update: vi.fn(() => qb),
+  upsert: vi.fn(() => qb),
+  delete: vi.fn(() => qb),
+  rpc: vi.fn(() => noopPromise),
+  eq: vi.fn(() => qb),
+  or: vi.fn(() => qb),
+  in: vi.fn(() => qb),
+  order: vi.fn(() => qb),
+  limit: vi.fn(() => qb),
+  single: vi.fn(() => Promise.resolve({ data: null, error: null })),
+  maybeSingle: vi.fn(() => Promise.resolve({ data: null, error: null })),
+};
+const mockSupabase = {
+  from: vi.fn(() => qb),
+  rpc: vi.fn(() => noopPromise),
+};
+
+vi.mock("../src/lib/supabase", () => ({
+  supabase: mockSupabase,
+}));
+
+/** -------- Service mock (ensure instanceof matches) -------- */
+const mockAcceptConnectionRequest = vi.fn();
+
+class MockConnectionRequestError extends Error {
+  code:
+    | "NOT_FOUND"
+    | "INVALID_STATE"
+    | "UNAUTHORIZED"
+    | "ALREADY_CONNECTED"
+    | "REQUEST_ALREADY_EXISTS"
+    | "BLOCKED"
+    | "TOO_MANY_REQUESTS";
+  statusCode: number;
+
+  constructor(
+    code: MockConnectionRequestError["code"],
+    statusCode: number,
+    message?: string
+  ) {
+    super(message ?? code);
+    this.name = "ConnectionRequestError";
+    this.code = code;
+    this.statusCode = statusCode;
+  }
+}
+
+// Match the type used in the router
+vi.mock("../src/types/ConnectionRequest", () => ({
+  ConnectionRequestError: MockConnectionRequestError,
+}));
+
+// IMPORTANT: path must match how the router imports it
+vi.mock("../src/services/connections.service", () => ({
+  acceptConnectionRequest: mockAcceptConnectionRequest,
+  ConnectionRequestError: MockConnectionRequestError,
+}));
+
+/** -------- App bootstrapping -------- */
+let app: ReturnType<Awaited<typeof import("../src/app")>["createApp"]>;
+
+async function buildApp() {
+  const mod = await import("../src/app");
+  return mod.createApp();
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  await vi.resetModules();
+  app = await buildApp();
+});
+
+/** -------- Test constants -------- */
+const BASE = "/api/connections/requests";
+const validBearer = "Bearer validtoken";
+
+// use real UUIDs to keep any zod/uuid checks happy (even though accept route only checks presence)
+const TEST_PROFILE_ID = "8d3c2a58-1a1e-4c2f-9d8f-0b8a3e3a12ab";
+const REQUEST_ID      = "3f5b0882-2cbb-4a6a-af7c-6a1cb1a32e77";
+
+/** =======================================================================
+ *  POST /connections/requests/:id/accept
+ *  ======================================================================= */
+describe("POST /api/connections/requests/:id/accept", () => {
+  it("200: accepts a pending request (happy path)", async () => {
+    mockJwtVerify.mockReturnValue({ sub: TEST_PROFILE_ID });
+    mockAcceptConnectionRequest.mockResolvedValue({ success: true });
+
+    const res = await request(app)
+      .post(`${BASE}/${REQUEST_ID}/accept`)
+      .set("Authorization", validBearer);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+    expect(mockAcceptConnectionRequest).toHaveBeenCalledWith(
+      REQUEST_ID,
+      TEST_PROFILE_ID
+    );
+  });
+
+  it("401: missing Authorization header", async () => {
+    const res = await request(app).post(`${BASE}/${REQUEST_ID}/accept`);
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ code: "NOT_AUTHENTICATED" });
+    expect(mockAcceptConnectionRequest).not.toHaveBeenCalled();
+  });
+
+  it("401: invalid JWT", async () => {
+    mockJwtVerify.mockImplementation(() => {
+      throw new Error("bad token");
+    });
+
+    const res = await request(app)
+      .post(`${BASE}/${REQUEST_ID}/accept`)
+      .set("Authorization", "Bearer bad");
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ code: "NOT_AUTHENTICATED" });
+    expect(mockAcceptConnectionRequest).not.toHaveBeenCalled();
+  });
+
+  it("404: request not found or not addressed to caller", async () => {
+    mockJwtVerify.mockReturnValue({ sub: TEST_PROFILE_ID });
+    mockAcceptConnectionRequest.mockRejectedValue(
+      new MockConnectionRequestError("NOT_FOUND", 404)
+    );
+
+    const res = await request(app)
+      .post(`${BASE}/${REQUEST_ID}/accept`)
+      .set("Authorization", validBearer);
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ code: "NOT_FOUND" });
+  });
+
+  it("409: invalid state (e.g., not pending)", async () => {
+    mockJwtVerify.mockReturnValue({ sub: TEST_PROFILE_ID });
+    mockAcceptConnectionRequest.mockRejectedValue(
+      new MockConnectionRequestError("INVALID_STATE", 409)
+    );
+
+    const res = await request(app)
+      .post(`${BASE}/${REQUEST_ID}/accept`)
+      .set("Authorization", validBearer);
+
+    expect(res.status).toBe(409);
+    expect(res.body).toEqual({ code: "INVALID_STATE" });
+  });
+
+  it("500: unexpected error bubbles to INTERNAL", async () => {
+    mockJwtVerify.mockReturnValue({ sub: TEST_PROFILE_ID });
+    mockAcceptConnectionRequest.mockRejectedValue(new Error("db blew up"));
+
+    const res = await request(app)
+      .post(`${BASE}/${REQUEST_ID}/accept`)
+      .set("Authorization", validBearer);
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ code: "INTERNAL" });
+  });
+});


### PR DESCRIPTION
with this PR, if user A send a request to user B, user B can safely:
- accept the request connect to user A
- decline the request
- won't be able to request if they are already connected to each other
- both users can check their connect list and show each other profileId and general information
- the connect request on the connect request list (both incoming and outgoing) wont be there anymore and on database the status updated as 'connected'
- both users can delete each other (unconnect safely)
- then they are still able to 'reconnect'

<img width="736" height="288" alt="image" src="https://github.com/user-attachments/assets/1651f41c-a803-4b33-8360-3823de0149bc" />
<img width="930" height="895" alt="image" src="https://github.com/user-attachments/assets/6779177e-1723-467c-90d8-1ea061c18b15" />
<img width="927" height="695" alt="image" src="https://github.com/user-attachments/assets/ea71de69-708d-432e-be59-1f6a84e43c1a" />

All test cases on backend passed smoothly